### PR TITLE
Fix unit tests in various files

### DIFF
--- a/src/components/__tests__/EntriesRelationList.spec.ts
+++ b/src/components/__tests__/EntriesRelationList.spec.ts
@@ -1,12 +1,12 @@
 // @ts-nocheck
 import EntriesRelationList from '@/components/EntriesRelationList.vue'
 import {afterEach, beforeEach, describe, expect, jest, test} from '@jest/globals'
-import {mount, DOMWrapper, VueWrapper} from '@vue/test-utils'
+import {DOMWrapper, mount, VueWrapper} from '@vue/test-utils'
 import _ from 'lodash'
 import {GlobalFilter, GlobalFilterSection, Rule} from '@/types'
 
 describe('EntriesRelationList.vue', () => {
-  let wrapper = mount(EntriesRelationList)
+  let wrapper: VueWrapper
   let ruleData: GlobalFilter['rule']
   let entryData1: GlobalFilterSection
   let entryData2: GlobalFilterSection
@@ -44,16 +44,14 @@ describe('EntriesRelationList.vue', () => {
         entryData2,
       ],
     }
-    const onUpdate = (rule: GlobalFilter['rule']) => {
-      wrapper.setProps({rule})
+    const onUpdate = async (rule: GlobalFilter['rule']) => {
+      await wrapper.setProps({rule})
     }
     wrapper = mount(EntriesRelationList, {
       props: {
-        rule: ruleData,
-        editable: true,
-      },
-      listeners: {
-        'update:rule': onUpdate,
+        'rule': ruleData,
+        'editable': true,
+        'onUpdate:rule': onUpdate,
       },
     })
   })
@@ -71,10 +69,10 @@ describe('EntriesRelationList.vue', () => {
     const component = wrapper.findComponent(EntriesRelationList)
     const categories = component.findAll('.entry-category')
     const values = component.findAll('.entry-value')
-    expect(categories.at(0)?.text()?.toLowerCase()).toContain(wantedEntryData[0][0].toLowerCase())
-    expect(values.at(0)?.text()?.toLowerCase()).toContain((wantedEntryData[0][1] as string).toLowerCase())
-    expect(categories.at(1)?.text()?.toLowerCase()).toContain(wantedEntryData[1][0].toLowerCase())
-    expect(values.at(1)?.text()?.toLowerCase()).toContain((wantedEntryData[1][1] as string).toLowerCase())
+    expect(categories.at(0).text().toLowerCase()).toContain(wantedEntryData[0][0].toLowerCase())
+    expect(values.at(0).text().toLowerCase()).toContain((wantedEntryData[0][1] as string).toLowerCase())
+    expect(categories.at(1).text().toLowerCase()).toContain(wantedEntryData[1][0].toLowerCase())
+    expect(values.at(1).text().toLowerCase()).toContain((wantedEntryData[1][1] as string).toLowerCase())
     expect(ruleData.sections[0].entries).toEqual(wantedEntryData)
   })
 
@@ -82,13 +80,12 @@ describe('EntriesRelationList.vue', () => {
     const wantedEntryData = ['ip', '1.2.3.4']
     const newRuleData = JSON.parse(JSON.stringify(ruleData))
     newRuleData.sections[0].entries = [wantedEntryData]
-    wrapper.setProps({rule: newRuleData})
-    await wrapper.vm.$nextTick()
+    await wrapper.setProps({rule: newRuleData})
     const component = wrapper.findComponent(EntriesRelationList)
     const categories = component.findAll('.entry-category')
     const values = component.findAll('.entry-value')
-    expect(categories.at(0)?.text()?.toLowerCase()).toContain(wantedEntryData[0].toLowerCase())
-    expect(values.at(0)?.text()?.toLowerCase()).toContain(wantedEntryData[1].toLowerCase())
+    expect(categories.at(0).text().toLowerCase()).toContain(wantedEntryData[0].toLowerCase())
+    expect(values.at(0).text().toLowerCase()).toContain(wantedEntryData[1].toLowerCase())
   })
 
   test('should not break if not given a prop', () => {
@@ -98,8 +95,7 @@ describe('EntriesRelationList.vue', () => {
   })
 
   test('should not break if data changes to invalid data', async () => {
-    (entryData1 as any) = {}
-    await wrapper.vm.$nextTick()
+    entryData1 = {}
     const component = wrapper.findComponent(EntriesRelationList)
     expect(component).toBeTruthy()
   })
@@ -108,13 +104,11 @@ describe('EntriesRelationList.vue', () => {
     test('should change section relation between `OR` and `AND` when clicked', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const section = component.findAll('.section').at(1)
-      const sectionRelationToggle = section?.find('.section-relation-toggle')
-      sectionRelationToggle?.trigger('click')
-      await wrapper.vm.$nextTick()
-      expect(sectionRelationToggle?.text()).toEqual('OR')
-      sectionRelationToggle?.trigger('click')
-      await wrapper.vm.$nextTick()
-      expect(sectionRelationToggle?.text()).toEqual('AND')
+      const sectionRelationToggle = section.find('.section-relation-toggle')
+      await sectionRelationToggle.trigger('click')
+      expect(sectionRelationToggle.text()).toEqual('OR')
+      await sectionRelationToggle.trigger('click')
+      expect(sectionRelationToggle.text()).toEqual('AND')
     })
 
     test('should not change section relation if section entries contains two entries of same category', async () => {
@@ -129,20 +123,18 @@ describe('EntriesRelationList.vue', () => {
           '/account',
         ],
       ]
-      wrapper.setProps({rule: newRuleData})
-      await wrapper.vm.$nextTick()
+      await wrapper.setProps({rule: newRuleData})
       const component = wrapper.findComponent(EntriesRelationList)
       const section = component.findAll('.section').at(0)
-      const sectionRelationToggle = section?.find('.section-relation-toggle')
-      sectionRelationToggle?.trigger('click')
-      await wrapper.vm.$nextTick()
-      expect(sectionRelationToggle?.text()).toEqual('OR')
+      const sectionRelationToggle = section.find('.section-relation-toggle')
+      await sectionRelationToggle.trigger('click')
+      expect(sectionRelationToggle.text()).toEqual('OR')
     })
   })
 
   describe('large data pagination', () => {
-    let checkedComponent: any
-    let checkedTable: any
+    let checkedComponent: VueWrapper
+    let checkedTable: DOMWrapper
     beforeEach(() => {
       entryData1 = {
         relation: 'AND',
@@ -208,8 +200,7 @@ describe('EntriesRelationList.vue', () => {
 
     test('should correctly render next page when next page button is clicked', async () => {
       const nextPageButton = checkedTable.find('.pagination-next')
-      nextPageButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await nextPageButton.trigger('click')
       checkedTable = checkedComponent.findAll('.entries-table').at(0)
       const entryRows = checkedTable.findAll('.entry-row')
       expect(entryRows.length).toEqual(10)
@@ -217,18 +208,15 @@ describe('EntriesRelationList.vue', () => {
 
     test('should have next page button disabled if currently in last page', async () => {
       const nextPageButton = checkedTable.find('.pagination-next')
-      nextPageButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await nextPageButton.trigger('click')
       expect(nextPageButton.attributes('disabled')).toBeTruthy()
     })
 
     test('should correctly render prev page when next prev button is clicked', async () => {
       const nextPageButton = checkedTable.find('.pagination-next')
-      nextPageButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await nextPageButton.trigger('click')
       const prevPageButton = checkedTable.find('.pagination-previous')
-      prevPageButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await prevPageButton.trigger('click')
       checkedTable = checkedComponent.findAll('.entries-table').at(0)
       const entryRows = checkedTable.findAll('.entry-row')
       expect(entryRows.length).toEqual(20)
@@ -322,8 +310,7 @@ describe('EntriesRelationList.vue', () => {
     test('should remove section', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const removeSectionButton = component.find('.remove-section-button')
-      removeSectionButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await removeSectionButton.trigger('click')
       const tables = wrapper.findAll('.entries-table')
       expect(tables.length).toEqual(1)
     })
@@ -358,8 +345,7 @@ describe('EntriesRelationList.vue', () => {
     test('should open new entry row', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       const newEntryRow = component.find('.new-entry-row')
       expect(newEntryRow.exists()).toBeTruthy()
     })
@@ -367,14 +353,12 @@ describe('EntriesRelationList.vue', () => {
     test('should add new entry from input when confirm button is clicked', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       const newEntryRow = component.find('.new-entry-row')
       const newEntryTextarea = newEntryRow.find('.new-entry-textarea')
-      newEntryTextarea.setValue('1.2.3.4#annotation')
+      await newEntryTextarea.setValue('1.2.3.4#annotation')
       const confirmAddEntryButton = component.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       expect((wrapper.vm as any).rule.sections[0].entries.length).toEqual(3)
       expect((wrapper.vm as any).rule.sections[0].entries[2]).toEqual(['ip', '1.2.3.4', 'annotation'])
     })
@@ -382,16 +366,14 @@ describe('EntriesRelationList.vue', () => {
     test('should add new entry from input with general annotation when confirm button is clicked', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       const newEntryRow = component.find('.new-entry-row')
       const newEntryTextarea = newEntryRow.find('.new-entry-textarea')
-      newEntryTextarea.setValue('1.2.3.4')
+      await newEntryTextarea.setValue('1.2.3.4')
       const newEntryAnnotation = newEntryRow.find('.new-entry-value-annotation-input')
-      newEntryAnnotation.setValue('annot')
+      await newEntryAnnotation.setValue('annot')
       const confirmAddEntryButton = component.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       expect((wrapper.vm as any).rule.sections[0].entries.length).toEqual(3)
       expect((wrapper.vm as any).rule.sections[0].entries[2]).toEqual(['ip', '1.2.3.4', 'annot'])
     })
@@ -399,14 +381,12 @@ describe('EntriesRelationList.vue', () => {
     test('should add multiple new entries from input when confirm button is clicked', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       const newEntryRow = component.find('.new-entry-row')
       const newEntryTextarea = newEntryRow.find('.new-entry-textarea')
-      newEntryTextarea.setValue('1.2.3.4#annotation\n127.0.0.1#localhost')
+      await newEntryTextarea.setValue('1.2.3.4#annotation\n127.0.0.1#localhost')
       const confirmAddEntryButton = component.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       expect((wrapper.vm as any).rule.sections[0].entries.length).toEqual(4)
       expect((wrapper.vm as any).rule.sections[0].entries[2]).toEqual(['ip', '1.2.3.4', 'annotation'])
       expect((wrapper.vm as any).rule.sections[0].entries[3]).toEqual(['ip', '127.0.0.1', 'localhost'])
@@ -416,16 +396,14 @@ describe('EntriesRelationList.vue', () => {
       'annotation from input when confirm button is clicked', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       const newEntryRow = component.find('.new-entry-row')
       const newEntryTextarea = newEntryRow.find('.new-entry-textarea')
-      newEntryTextarea.setValue('1.2.3.4\n127.0.0.1#localhost')
+      await newEntryTextarea.setValue('1.2.3.4\n127.0.0.1#localhost')
       const newEntryAnnotation = newEntryRow.find('.new-entry-value-annotation-input')
-      newEntryAnnotation.setValue('annot')
+      await newEntryAnnotation.setValue('annot')
       const confirmAddEntryButton = component.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       expect((wrapper.vm as any).rule.sections[0].entries.length).toEqual(4)
       expect((wrapper.vm as any).rule.sections[0].entries[2]).toEqual(['ip', '1.2.3.4', 'annot'])
       expect((wrapper.vm as any).rule.sections[0].entries[3]).toEqual(['ip', '127.0.0.1', 'localhost'])
@@ -434,21 +412,18 @@ describe('EntriesRelationList.vue', () => {
     test('should add new entries from name-value input when confirm button is clicked', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       const newEntryRow = component.find('.new-entry-row')
       const typeSelection = newEntryRow.find('.new-entry-type-selection')
-      typeSelection.trigger('click')
+      await typeSelection.trigger('click')
       const options = typeSelection.findAll('option')
-      typeSelection.setValue(options.at(7)?.element.value)
-      await wrapper.vm.$nextTick()
+      await typeSelection.setValue(options.at(7).element.value)
       const newEntryInputName = newEntryRow.find('.new-entry-name-input')
-      newEntryInputName.setValue('something')
+      await newEntryInputName.setValue('something')
       const newEntryInputValue = newEntryRow.find('.new-entry-value-annotation-input')
-      newEntryInputValue.setValue('right')
+      await newEntryInputValue.setValue('right')
       const confirmAddEntryButton = component.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       expect((wrapper.vm as any).rule.sections[0].entries.length).toEqual(3)
       expect((wrapper.vm as any).rule.sections[0].entries[2]).toEqual(['headers', ['something', 'right']])
     })
@@ -457,21 +432,18 @@ describe('EntriesRelationList.vue', () => {
       'input when confirm button is clicked if has too few arguments', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       const newEntryRow = component.find('.new-entry-row')
       const typeSelection = newEntryRow.find('.new-entry-type-selection')
-      typeSelection.trigger('click')
+      await typeSelection.trigger('click')
       const options = typeSelection.findAll('option')
-      typeSelection.setValue(options.at(7)?.element.value)
-      await wrapper.vm.$nextTick()
+      await typeSelection.setValue(options.at(7).element.value)
       const newEntryInputName = newEntryRow.find('.new-entry-name-input')
-      newEntryInputName.setValue('something')
+      await newEntryInputName.setValue('something')
       const newEntryInputValue = newEntryRow.find('.new-entry-value-annotation-input')
-      newEntryInputValue.setValue('')
+      await newEntryInputValue.setValue('')
       const confirmAddEntryButton = component.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       expect((wrapper.vm as any).rule.sections[0].entries.length).toEqual(2)
     })
 
@@ -491,23 +463,20 @@ describe('EntriesRelationList.vue', () => {
       const component = wrapper.findComponent(EntriesRelationList)
       // set relation to AND
       const sectionRelationToggle = component.findAll('.section-relation-toggle').at(0)
-      sectionRelationToggle?.trigger('click')
-      await wrapper.vm.$nextTick()
-      expect(sectionRelationToggle?.text()).toEqual('AND')
+      await sectionRelationToggle.trigger('click')
+      expect(sectionRelationToggle.text()).toEqual('AND')
       // open new entry row
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       // add input to new entry row
       const newEntryRow = component.find('.new-entry-row')
       const newEntryTextarea = newEntryRow.find('.new-entry-textarea')
-      newEntryTextarea.setValue('1.2.3.4#annotation\n1.2.3.5#wow')
+      await newEntryTextarea.setValue('1.2.3.4#annotation\n1.2.3.5#wow')
       // confirm add new entry
       const confirmAddEntryButton = component.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       // check
-      expect(sectionRelationToggle?.text()).toEqual('OR')
+      expect(sectionRelationToggle.text()).toEqual('OR')
     })
 
     test('should not set section relation to `OR` if no more than one item of same category added', async () => {
@@ -518,73 +487,69 @@ describe('EntriesRelationList.vue', () => {
           '/login',
         ],
       ]
-      wrapper.setProps({rule: newRuleData})
-      await wrapper.vm.$nextTick()
+      await wrapper.setProps({rule: newRuleData})
       const component = wrapper.findComponent(EntriesRelationList)
       // check relation is AND
       const sectionRelationToggle = component.findAll('.section-relation-toggle').at(0)
-      expect(sectionRelationToggle?.text()).toEqual('AND')
+      expect(sectionRelationToggle.text()).toEqual('AND')
       // open new entry row
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       // add input to new entry row
       const newEntryRow = component.find('.new-entry-row')
       const newEntryTextarea = newEntryRow.find('.new-entry-textarea')
-      newEntryTextarea.setValue('1.2.3.4#annotation')
+      await newEntryTextarea.setValue('1.2.3.4#annotation')
       // confirm add new entry
       const confirmAddEntryButton = component.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       // check relation is still AND
-      expect(sectionRelationToggle?.text()).toEqual('AND')
+      expect(sectionRelationToggle.text()).toEqual('AND')
     })
 
     test('should not set section relation to `OR` if two headers added', async () => {
+      const headerName = 'user-agent'
+      const headerValue = 'curl'
       const component = wrapper.findComponent(EntriesRelationList)
       // set relation to AND
-      const sectionRelationToggle: DOMWrapper<Element> | undefined = component.findAll('.section-relation-toggle').at(0)
-      sectionRelationToggle?.trigger('click')
-      await wrapper.vm.$nextTick()
-      expect(sectionRelationToggle?.text()).toEqual('AND')
+      const sectionRelationToggle: DOMWrapper = component.findAll('.section-relation-toggle').at(0)
+      await sectionRelationToggle.trigger('click')
+      expect(sectionRelationToggle.text()).toEqual('AND')
       // open new entry row
       let addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       let newEntryRow = component.find('.new-entry-row')
       // change entry type to headers
       let typeSelection = newEntryRow.find('.new-entry-type-selection')
-      typeSelection.trigger('click')
+      await typeSelection.trigger('click')
       let options = typeSelection.findAll('option')
-      typeSelection.setValue(options.at(7)?.element.value)
-      await wrapper.vm.$nextTick()
+      await typeSelection.setValue(options.at(7).element.value)
       // add input to new entry row
-      let newEntryTextarea = newEntryRow.find('.new-entry-textarea')
-      newEntryTextarea.setValue('something\nright\nhere')
+      let newEntryInputName = newEntryRow.find('.new-entry-name-input')
+      await newEntryInputName.setValue(headerName)
+      let newEntryInputValue = newEntryRow.find('.new-entry-value-annotation-input')
+      await newEntryInputValue.setValue(headerValue)
       // confirm add new entry
       let confirmAddEntryButton = component.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       // open new entry row - second time
       addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       newEntryRow = component.find('.new-entry-row')
       // change entry type to headers - second time
       typeSelection = newEntryRow.find('.new-entry-type-selection')
-      typeSelection.trigger('click')
+      await typeSelection.trigger('click')
       options = typeSelection.findAll('option')
-      typeSelection.setValue(options.at(7)?.element.value)
-      await wrapper.vm.$nextTick()
+      await typeSelection.setValue(options.at(7).element.value)
       // add input to new entry row - second time
-      newEntryTextarea = newEntryRow.find('.new-entry-textarea')
-      newEntryTextarea.setValue('something\nright\nhere')
+      newEntryInputName = newEntryRow.find('.new-entry-name-input')
+      await newEntryInputName.setValue(headerName)
+      newEntryInputValue = newEntryRow.find('.new-entry-value-annotation-input')
+      await newEntryInputValue.setValue(headerValue)
       // confirm add new entry - second time
       confirmAddEntryButton = component.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       // check
-      expect(sectionRelationToggle?.text()).toEqual('AND')
+      expect(sectionRelationToggle.text()).toEqual('AND')
     })
   })
 
@@ -592,11 +557,9 @@ describe('EntriesRelationList.vue', () => {
     test('should close adding mode', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       const cancelEntryButton = component.find('.cancel-entry-button')
-      cancelEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await cancelEntryButton.trigger('click')
       expect((wrapper.vm as any).newEntrySectionIndex).toEqual(-1)
     })
     test('should remove empty section', async () => {
@@ -611,11 +574,9 @@ describe('EntriesRelationList.vue', () => {
       })
       const component = wrapper.findComponent(EntriesRelationList)
       const addSectionButton = component.find('.add-section-button')
-      addSectionButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addSectionButton.trigger('click')
       const cancelEntryButton = component.find('.cancel-entry-button')
-      cancelEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await cancelEntryButton.trigger('click')
       expect(component.findAll('.section').length).toEqual(0)
     })
   })
@@ -624,8 +585,7 @@ describe('EntriesRelationList.vue', () => {
     test('should remove entry', async () => {
       const component = wrapper.findComponent(EntriesRelationList)
       const removeEntryButton = component.find('.remove-entry-button')
-      removeEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await removeEntryButton.trigger('click')
       expect((wrapper.vm as any).rule.sections[0].entries.length).toEqual(1)
     })
     test('should remove section if no entries left', async () => {
@@ -653,9 +613,8 @@ describe('EntriesRelationList.vue', () => {
       })
       const component = wrapper.findComponent(EntriesRelationList)
       const section = component.findAll('.section').at(1)
-      const removeEntryButton = section?.find('.remove-entry-button')
-      removeEntryButton?.trigger('click')
-      await wrapper.vm.$nextTick()
+      const removeEntryButton = section.find('.remove-entry-button')
+      await removeEntryButton.trigger('click')
       expect(component.findAll('.section').length).toEqual(rule.sections.length - 1)
     })
   })
@@ -672,65 +631,59 @@ describe('EntriesRelationList.vue', () => {
       component = wrapper.findComponent(EntriesRelationList)
       // open new entry row
       const addEntryButton = component.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await addEntryButton.trigger('click')
       // add input to new entry row
       newEntryRows = component.findAll('.new-entry-row')
       newEntryRow = newEntryRows.at(0)
       newEntryTextarea = newEntryRow.find('.new-entry-textarea')
       newEntrySecondAttr = newEntryRow.find('.new-entry-value-annotation-input')
       const typeSelection = newEntryRow.find('.new-entry-type-selection')
-      typeSelection.trigger('click')
+      await typeSelection.trigger('click')
       options = typeSelection.findAll('option')
       confirmAddEntryButton = component.find('.confirm-add-entry-button')
     })
     test('should not add entry if it contains an error or empty first attr', async () => {
-      newEntryTextarea.setValue('')
+      await newEntryTextarea.setValue('')
       // confirm add new entry
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       // check
       const entries = component.findAll('.entry-row')
       expect(entries.length).toEqual(entryData1.entries.length + entryData2.entries.length)
       expect(newEntryRows.length).toEqual(1)
     })
     test('should highlight duplicated entries', async () => {
-      newEntryTextarea.setValue('1.2.3.4\n1.2.3.4\n1.2.3.4')
+      await newEntryTextarea.setValue('1.2.3.4\n1.2.3.4\n1.2.3.4')
       // confirm add new entry
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       // check
       expect((wrapper.vm as any).duplicatedEntries.length).toEqual(1)
     })
     test('should validate duplicated entries if category is args, cookies, headers', async () => {
       // open new entry row
-      const section = component.find('.section')
-      const addEntryButton = section.find('.add-entry-button')
-      addEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      const component = wrapper.findComponent(EntriesRelationList)
+      const addEntryButton = component.find('.add-entry-button')
+      await addEntryButton.trigger('click')
       // change entry type to headers
       const typeSelection = newEntryRow.find('.new-entry-type-selection')
-      typeSelection.trigger('click')
+      await typeSelection.trigger('click')
       options = typeSelection.findAll('option')
-      typeSelection.setValue(options.at(7)?.element.value)
-      await wrapper.vm.$nextTick()
+      await typeSelection.setValue(options.at(7).element.value)
       // add input to new entry row
-      newEntryRow = section.find('.new-entry-row')
+      newEntryRow = component.find('.new-entry-row')
       const newEntryFirstAttr = newEntryRow.find('.new-entry-name-input')
       const duplicateValues = entryData2.entries[0][1]
-      newEntryFirstAttr.setValue(duplicateValues[0])
-      newEntrySecondAttr.setValue(duplicateValues[1])
+      await newEntryFirstAttr.setValue(duplicateValues[0])
+      await newEntrySecondAttr.setValue(duplicateValues[1])
       // confirm add new entry
       confirmAddEntryButton = newEntryRow.find('.confirm-add-entry-button')
-      confirmAddEntryButton.trigger('click')
-      await wrapper.vm.$nextTick()
+      await confirmAddEntryButton.trigger('click')
       // check
       expect((wrapper.vm as any).duplicatedEntries.length).toEqual(1)
     })
     // TODO: Fix regex test for rust standards and re-apply this
     // test('should validate value as regex if category is path, query, or uri', async () => {
     //   // change entry type to path
-    //   await wrapper.vm.$nextTick()
+    //   await nextTick()
     //   newEntryTextarea.setValue('\\')
     //   // check
     //   expect((wrapper.vm as any).entriesErrors.length).toEqual(1)
@@ -738,29 +691,27 @@ describe('EntriesRelationList.vue', () => {
     test('should validate value as ip if category is ip', async () => {
       // change entry type to ip
       const typeSelection = newEntryRow.find('.new-entry-type-selection')
-      typeSelection.trigger('click')
+      await typeSelection.trigger('click')
       options = typeSelection.findAll('option')
-      typeSelection.setValue(options.at(4)?.element.value)
-      await wrapper.vm.$nextTick()
-      newEntryTextarea.setValue('1.1.1.1.')
+      await typeSelection.setValue(options.at(4).element.value)
+      await newEntryTextarea.setValue('1.1.1.1.')
       // check
       expect((wrapper.vm as any).entriesErrors.length).toEqual(1)
     })
     test('should validate value as non-empty if category is not ip, path, query, uri', async () => {
       // change entry type to method
       const typeSelection = newEntryRow.find('.new-entry-type-selection')
-      typeSelection.trigger('click')
+      await typeSelection.trigger('click')
       options = typeSelection.findAll('option')
-      typeSelection.setValue(options.at(3)?.element.value)
-      await wrapper.vm.$nextTick()
-      newEntryTextarea.setValue(' ')
+      await typeSelection.setValue(options.at(3).element.value)
+      await newEntryTextarea.setValue(' ')
       // check
       expect((wrapper.vm as any).entriesErrors.length).toEqual(1)
     })
     // TODO: Fix regex test for rust standards and re-apply this
     // test('should validate second attribute if category is args, cookies, headers', async () => {
     //   // change entry type to headers
-    //   await wrapper.vm.$nextTick()
+    //   await nextTick()
     //   newEntrySecondAttr.setValue('\\')
     //   // check
     //   expect((wrapper.vm as any).entriesErrors.length).toEqual(1)
@@ -768,14 +719,11 @@ describe('EntriesRelationList.vue', () => {
     test('should clear errors', async () => {
       // change entry type to headers
       const typeSelection = newEntryRow.find('.new-entry-type-selection')
-      typeSelection.trigger('click')
+      await typeSelection.trigger('click')
       options = typeSelection.findAll('option')
-      typeSelection.setValue(options.at(7)?.element.value)
-      await wrapper.vm.$nextTick()
-      newEntrySecondAttr.setValue('\\')
-      await wrapper.vm.$nextTick()
-      newEntrySecondAttr.setValue('something')
-      await wrapper.vm.$nextTick()
+      await typeSelection.setValue(options.at(7).element.value)
+      await newEntrySecondAttr.setValue('\\')
+      await newEntrySecondAttr.setValue('something')
       // check
       expect((wrapper.vm as any).entriesErrors.length).toEqual(0)
     })

--- a/src/doc-editors/GlobalFilterListEditor.vue
+++ b/src/doc-editors/GlobalFilterListEditor.vue
@@ -252,11 +252,6 @@ export default defineComponent({
       this.$emit('form-invalid', isFormInvalid)
     },
 
-    // updateRule(newRule: GlobalFilter['rule']) {
-    //   this.localDoc.rule = newRule
-    //   this.emitDocUpdate()
-    // },
-
     setRuleRelation(relation: Relation) {
       this.localDoc.rule.relation = relation
       this.emitDocUpdate()
@@ -316,7 +311,6 @@ export default defineComponent({
         })
       }
       const url = this.localDoc.source
-      console.log('GlobalFilterListEditor url: ', url)
       RequestsUtils.sendRequest({methodName: 'GET', url: `tools/fetch?url=${url}`}).then((response: AxiosResponse) => {
         const data = response.data
         let entries: GlobalFilterSectionEntry[]

--- a/src/doc-editors/RateLimitsEditor.vue
+++ b/src/doc-editors/RateLimitsEditor.vue
@@ -244,22 +244,22 @@
                 <template v-if="newSecurityPolicyConnections.length > 0">
                   <td>
                     <div class="select is-small">
-                      <select v-model="newSecurityPolicyConnectionData.map"
-                              @change="newSecurityPolicyConnectionData.entryIndex = 0"
+                      <select v-model="newSecurityPolicyConnectionDataMapId"
+                              @change="newSecurityPolicyConnectionDataChanged()"
                               class="new-connection-map"
                               data-qa="site-name-dropdown"
                               title="Type">
-                        <option v-for="map in newSecurityPolicyConnections" :key="map.id" :value="map">
+                        <option v-for="map in newSecurityPolicyConnections" :key="map.id" :value="map.id">
                           {{ map.name }}
                         </option>
                       </select>
                     </div>
                   </td>
                   <td>
-                    {{ newSecurityPolicyConnectionData.map.id }}
+                    {{ newSecurityPolicyConnectionData.map?.id }}
                   </td>
                   <td>
-                    {{ newSecurityPolicyConnectionData.map.match }}
+                    {{ newSecurityPolicyConnectionData.map?.match }}
                   </td>
                   <td>
                     <div class="select is-small">
@@ -404,6 +404,7 @@ export default defineComponent({
         map: SecurityPolicy,
         entryIndex: number,
       },
+      newSecurityPolicyConnectionDataMapId: null,
       newSecurityPolicyConnectionOpened: false,
       connectedSecurityPoliciesEntries: [],
       keysAreValid: true,
@@ -561,11 +562,19 @@ export default defineComponent({
       this.newSecurityPolicyConnectionOpened = true
       this.newSecurityPolicyConnectionData.map =
           this.newSecurityPolicyConnections.length > 0 ? this.newSecurityPolicyConnections[0] : null
+      this.newSecurityPolicyConnectionDataMapId = this.newSecurityPolicyConnectionData.map?.id
       this.newSecurityPolicyConnectionData.entryIndex = 0
     },
 
     closeNewSecurityPolicyConnection() {
       this.newSecurityPolicyConnectionOpened = false
+    },
+
+    newSecurityPolicyConnectionDataChanged() {
+      this.newSecurityPolicyConnectionData.entryIndex = 0
+      this.newSecurityPolicyConnectionData.map = this.newSecurityPolicyConnections.find((connection) => {
+        return connection.id === this.newSecurityPolicyConnectionDataMapId
+      })
     },
 
     addNewSecurityPolicyConnection() {
@@ -627,6 +636,7 @@ export default defineComponent({
         this.getConnectedSecurityPoliciesEntries()
         this.newSecurityPolicyConnectionData.map =
             this.newSecurityPolicyConnections.length > 0 ? this.newSecurityPolicyConnections[0] : null
+        this.newSecurityPolicyConnectionDataMapId = this.newSecurityPolicyConnectionData.map?.id
       })
     },
 

--- a/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
+++ b/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
@@ -1,7 +1,6 @@
 import ContentFilterEditor from '@/doc-editors/ContentFilterProfileEditor.vue'
 import {beforeEach, describe, expect, jest, test} from '@jest/globals'
 import {shallowMount} from '@vue/test-utils'
-// import Vue from 'vue'
 import {
   ArgsCookiesHeadersType,
   ContentFilterEntryMatch,
@@ -12,7 +11,6 @@ import {
   NamesRegexType,
 } from '@/types'
 import AutocompleteInput from '@/components/AutocompleteInput.vue'
-// @ts-ignore
 import _ from 'lodash'
 import axios from 'axios'
 
@@ -136,11 +134,9 @@ describe('ContentFilterProfileEditor.vue', () => {
     }
     wrapper = shallowMount(ContentFilterEditor, {
       props: {
-        selectedDoc: docs[0],
-        selectedBranch: 'master',
-      },
-      listeners: {
-        'update:selectedDoc': onUpdate,
+        'selectedDoc': docs[0],
+        'selectedBranch': 'master',
+        'onUpdate:selectedDoc': onUpdate,
       },
     })
     await wrapper.vm.$nextTick()

--- a/src/doc-editors/__tests__/GlobalFilterListEditor.spec.ts
+++ b/src/doc-editors/__tests__/GlobalFilterListEditor.spec.ts
@@ -1,20 +1,18 @@
-// @ts-nocheck
 import GlobalFilterListEditor from '@/doc-editors/GlobalFilterListEditor.vue'
 import {beforeEach, describe, expect, jest, test} from '@jest/globals'
-import {shallowMount} from '@vue/test-utils'
+import {shallowMount, VueWrapper} from '@vue/test-utils'
 import {GlobalFilter, GlobalFilterSectionEntry} from '@/types'
 import ResponseAction from '@/components/ResponseAction.vue'
 import TagsAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import EntriesRelationList from '@/components/EntriesRelationList.vue'
 import axios from 'axios'
-import {nextTick} from 'vue'
 
 jest.mock('axios')
 
 describe('GlobalFilterListEditor.vue', () => {
   let docs: GlobalFilter[]
-  let wrapper: any
+  let wrapper: VueWrapper
   beforeEach(() => {
     docs = [{
       'id': 'xlbp148c',
@@ -127,19 +125,18 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     describe('sections entries display', () => {
-      test('should display correct zero amount of sections', async () => {
+      test('should display correct zero amount of sections', () => {
         docs[0].rule.sections = []
         wrapper = shallowMount(GlobalFilterListEditor, {
           props: {
             selectedDoc: docs[0],
           },
         })
-        await wrapper.vm.$nextTick()
         const display = wrapper.find('.sections-entries-display')
         expect(display.text()).toContain('0 sections')
       })
 
-      test('should display correct zero amount of entries', async () => {
+      test('should display correct zero amount of entries', () => {
         docs[0].rule.sections = [
           {'relation': 'OR', 'entries': []},
         ]
@@ -148,12 +145,11 @@ describe('GlobalFilterListEditor.vue', () => {
             selectedDoc: docs[0],
           },
         })
-        await wrapper.vm.$nextTick()
         const display = wrapper.find('.sections-entries-display')
         expect(display.text()).toContain('0 entries')
       })
 
-      test('should display correct singular amount of sections', async () => {
+      test('should display correct singular amount of sections', () => {
         docs[0].rule.sections = [
           {'relation': 'OR', 'entries': [['ip', '1.1.1.1', null]]},
         ]
@@ -162,12 +158,11 @@ describe('GlobalFilterListEditor.vue', () => {
             selectedDoc: docs[0],
           },
         })
-        await wrapper.vm.$nextTick()
         const display = wrapper.find('.sections-entries-display')
         expect(display.text()).toContain('1 section')
       })
 
-      test('should display correct singular amount of entries', async () => {
+      test('should display correct singular amount of entries', () => {
         docs[0].rule.sections = [
           {'relation': 'OR', 'entries': [['ip', '1.1.1.1', null]]},
         ]
@@ -176,7 +171,6 @@ describe('GlobalFilterListEditor.vue', () => {
             selectedDoc: docs[0],
           },
         })
-        await wrapper.vm.$nextTick()
         const display = wrapper.find('.sections-entries-display')
         expect(display.text()).toContain('1 entry')
       })
@@ -195,14 +189,13 @@ describe('GlobalFilterListEditor.vue', () => {
 
   describe('form data when non editable', () => {
     // non editable if source is not 'self-managed'
-    beforeEach(async () => {
+    beforeEach(() => {
       docs[0].source = 'https://example.com'
       wrapper = shallowMount(GlobalFilterListEditor, {
         props: {
           selectedDoc: docs[0],
         },
       })
-      await wrapper.vm.$nextTick()
     })
 
     test('should hide sections relation mode', () => {
@@ -210,12 +203,12 @@ describe('GlobalFilterListEditor.vue', () => {
       expect(container.exists()).toBeFalsy()
     })
 
-    test('should hide remove all sections button', async () => {
+    test('should hide remove all sections button', () => {
       const button = wrapper.find('.remove-all-sections-button')
       expect(button.exists()).toBeFalsy()
     })
 
-    test('should display update now button', async () => {
+    test('should display update now button', () => {
       const button = wrapper.find('.update-now-button')
       expect(button.exists()).toBeTruthy()
     })
@@ -227,7 +220,7 @@ describe('GlobalFilterListEditor.vue', () => {
   })
 
   describe('tags management', () => {
-    test('should emit doc update when adding tags', async () => {
+    test('should emit doc update when adding tags', () => {
       const newTag = 'test-tag'
       const newTagInputValue = `${docs[0].tags.join(' ')} ${newTag}`
       const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
@@ -235,53 +228,48 @@ describe('GlobalFilterListEditor.vue', () => {
       // change tags
       const tagAutocompleteInput = wrapper.findComponent(TagAutocompleteInput)
       tagAutocompleteInput.vm.$emit('tag-changed', newTagInputValue)
-      await wrapper.vm.$nextTick()
       // check
       expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
       expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
     })
 
-    test('should emit form validness when EntriesRelationList is validated', async () => {
+    test('should emit form validness when EntriesRelationList is validated', () => {
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       entriesRelationListComponent.vm.$emit('invalid', false)
-      await wrapper.vm.$nextTick()
       // check
       expect(wrapper.emitted('form-invalid')).toBeTruthy()
     })
 
-    test('should set document tags to be an empty array if empty string provided', async () => {
+    test('should set document tags to be an empty array if empty string provided', () => {
       const newTagInputValue = ''
       const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
       wantedEmit.tags = []
       // change tags
       const tagAutocompleteInput = wrapper.findComponent(TagAutocompleteInput)
       tagAutocompleteInput.vm.$emit('tag-changed', newTagInputValue)
-      await wrapper.vm.$nextTick()
       // check
       expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
       expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
     })
 
-    test('should set tags input to be an empty string if document tags do not exist', async () => {
+    test('should set tags input to be an empty string if document tags do not exist', () => {
       delete docs[0].tags
       wrapper = shallowMount(GlobalFilterListEditor, {
         props: {
           selectedDoc: docs[0],
         },
       })
-      await wrapper.vm.$nextTick()
       const tagAutocompleteInput = wrapper.findComponent(TagAutocompleteInput)
       expect(tagAutocompleteInput.props('initialTag')).toEqual('')
     })
 
-    test('should set tags input to be an empty string if document tags is empty', async () => {
+    test('should set tags input to be an empty string if document tags is empty', () => {
       docs[0].tags = []
       wrapper = shallowMount(GlobalFilterListEditor, {
         props: {
           selectedDoc: docs[0],
         },
       })
-      await wrapper.vm.$nextTick()
       const tagAutocompleteInput = wrapper.findComponent(TagAutocompleteInput)
       expect(tagAutocompleteInput.props('initialTag')).toEqual('')
     })
@@ -354,21 +342,20 @@ describe('GlobalFilterListEditor.vue', () => {
     })
   })
 
-  test('should remove all entries relation data from component when clear button is clicked', async () => {
+  test('should remove all entries relation data from component when clear button is clicked', () => {
     const wantedRule: GlobalFilter['rule'] = {
       relation: docs[0].rule.relation,
       sections: [],
     }
     const button = wrapper.find('.remove-all-sections-button')
     button.trigger('click')
-    await wrapper.vm.$nextTick()
     const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
     expect(entriesRelationListComponent.props('rule')).toEqual(wantedRule)
   })
 
   describe('update now button', () => {
     let resolveData: any
-    beforeEach(async () => {
+    beforeEach(() => {
       resolveData = {}
       jest.spyOn(axios, 'get').mockImplementation((path) => {
         if (path.includes('/conf/api/v2/tools/fetch')) {
@@ -382,7 +369,6 @@ describe('GlobalFilterListEditor.vue', () => {
           selectedDoc: docs[0],
         },
       })
-      await wrapper.vm.$nextTick()
     })
 
     test('should update entries relation component with correct data - ipv4 array', async () => {
@@ -428,12 +414,9 @@ describe('GlobalFilterListEditor.vue', () => {
         },
       }
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await wrapper.vm.$nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await wrapper.vm.$nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
-      expect(entriesRelationListComponent).exists
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
 
@@ -480,10 +463,8 @@ describe('GlobalFilterListEditor.vue', () => {
         },
       }
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await wrapper.vm.$nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await wrapper.vm.$nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
@@ -531,10 +512,8 @@ describe('GlobalFilterListEditor.vue', () => {
         },
       }
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await wrapper.vm.$nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await wrapper.vm.$nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
@@ -573,10 +552,8 @@ describe('GlobalFilterListEditor.vue', () => {
         },
       }
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await wrapper.vm.$nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await wrapper.vm.$nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
@@ -615,10 +592,8 @@ describe('GlobalFilterListEditor.vue', () => {
         },
       }
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await wrapper.vm.$nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await wrapper.vm.$nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
@@ -669,10 +644,8 @@ describe('GlobalFilterListEditor.vue', () => {
         },
       }
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await wrapper.vm.$nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await wrapper.vm.$nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
@@ -723,10 +696,8 @@ describe('GlobalFilterListEditor.vue', () => {
         },
       }
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await wrapper.vm.$nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await wrapper.vm.$nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
@@ -768,10 +739,8 @@ describe('GlobalFilterListEditor.vue', () => {
           `${wantedEntries[3][1]}`,
       }
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await wrapper.vm.$nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await wrapper.vm.$nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
@@ -813,10 +782,8 @@ describe('GlobalFilterListEditor.vue', () => {
           `${wantedEntries[3][1]}`,
       }
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await wrapper.vm.$nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await wrapper.vm.$nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
@@ -847,10 +814,8 @@ describe('GlobalFilterListEditor.vue', () => {
       const wantedData: GlobalFilter['rule'] = JSON.parse(JSON.stringify(globalFilter.rule))
       resolveData = {data: globalFilter}
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
@@ -875,10 +840,8 @@ describe('GlobalFilterListEditor.vue', () => {
         },
       }
       const button = wrapper.find('.update-now-button')
-      button.trigger('click')
-      await wrapper.vm.$nextTick()
+      await button.trigger('click')
       await wrapper.vm.$forceUpdate()
-      await wrapper.vm.$nextTick()
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })

--- a/src/doc-editors/__tests__/RateLimitsEditor.spec.ts
+++ b/src/doc-editors/__tests__/RateLimitsEditor.spec.ts
@@ -95,10 +95,14 @@ describe('RateLimitsEditor.vue', () => {
     mockRouter = {
       push: jest.fn(),
     }
+    const onUpdate = async (selectedDoc: RateLimit) => {
+      await wrapper.setProps({selectedDoc})
+    }
     wrapper = mount(RateLimitsEditor, {
       props: {
-        selectedDoc: rateLimitsDocs[0],
-        selectedBranch: selectedBranch,
+        'selectedDoc': rateLimitsDocs[0],
+        'selectedBranch': selectedBranch,
+        'onUpdate:selectedDoc': onUpdate,
       },
       global: {
         mocks: {
@@ -137,8 +141,6 @@ describe('RateLimitsEditor.vue', () => {
       selection = responseActionComponents.at(1).find('.action-type-selection')
       options = selection.findAll('option')
       await selection.setValue(options.at(5).element.value)
-      // Simulate selectedDoc emit and update
-      await wrapper.setProps({selectedDoc: wrapper.vm.localDoc})
       expect(wrapper.find('.up-to-one-ban').exists()).toBeTruthy()
     })
 


### PR DESCRIPTION
Fix unit tests in EntriesRelationList.spec.ts
Fix unit tests in ContentFilterProfileEditor.spec.ts
Fix unit tests in GlobalFilterListEditor.spec.ts
Fix unit tests in RateLimitsEditor.spec.ts
Remove unnecessary code from GlobalFilterListEditor.vue
Change site-name-dropdown select tag in RateLimitEditor.vue Linked URLs table to work with non-object value

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>