### PR TITLE
Add unit tests to meet our coverage threshold. `doc editors` and `views` directory

### DIFF
--- a/src/doc-editors/ContentFilterProfileEditor.vue
+++ b/src/doc-editors/ContentFilterProfileEditor.vue
@@ -66,13 +66,11 @@
                      class="content-type-option-wrapper mb-3">
                   <label class="checkbox is-size-7">
                     <input type="checkbox"
-                           @change="updateContentType(contentTypeOption.value,
-                           getContentTypeStatus(contentTypeOption.value))"
+                           @change="updateContentType(contentTypeOption.value, $event.target.checked)"
                            class="checkbox-input"
                            :data-qa="`content-type-${contentTypeOption.value}-checkbox`"
                            :class="`content-type-${contentTypeOption.value}-input`"
-                           :checked="getContentTypeStatus(contentTypeOption.value)"
-                           >
+                           :checked="getContentTypeStatus(contentTypeOption.value)">
                     {{ contentTypeOption.displayName }}
                   </label>
                 </div>
@@ -121,9 +119,9 @@
                   </td>
                   <td class="is-size-7 width-20px">
                     <a title="remove entry"
-                       data-qa="remove-entry-btn"
+                       data-qa="remove-tag-entry-btn"
                        tabindex="0"
-                       class="is-small has-text-grey remove-entry-button"
+                       class="is-small has-text-grey remove-tag-entry-button"
                        @click="removeTag(section, idx)"
                        @keypress.space.prevent
                        @keypress.space="removeTag(section, idx)"
@@ -134,7 +132,7 @@
                 </tr>
                 <tr>
                   <td>
-                    <autocomplete-input
+                    <tag-autocomplete-input
                         v-if="addNewColName === section"
                         selection-type="single"
                         title="Tag"
@@ -142,13 +140,13 @@
                         :clear-input-after-selection="true"
                         :auto-focus="true"
                         @keydown.esc="cancelAddNewTag"
-                        @value-submitted="addTag(section, $event)"/>
+                        @tag-submitted="addTag(section, $event)"/>
                   </td>
                   <td class="is-size-7 width-20px">
                     <a title="add new entry"
-                       data-qa="new-entry-btn"
+                       data-qa="new-tag-entry-btn"
                        tabindex="0"
-                       class="is-size-7 width-20px is-small has-text-grey add-new-entry-button"
+                       class="is-size-7 width-20px is-small has-text-grey add-new-tag-entry-button"
                        @click="openTagInput(section)"
                        @keypress.space.prevent
                        @keypress.space="openTagInput(section)"
@@ -488,6 +486,7 @@
                         </td>
                         <td class="has-text-centered width-5pct">
                           <button title="Delete entry"
+                                  data-qa="remove-entry-btn"
                                   :data-curie="genRowKey(tab, 'names', idx)"
                                   @click="deleteEntryRow(tab, 'names', idx)"
                                   class="button is-light is-small remove-entry-button">
@@ -598,6 +597,7 @@ import {
   Dictionary,
 } from '@/types'
 import AutocompleteInput, {AutocompleteSuggestion} from '@/components/AutocompleteInput.vue'
+import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import Utils from '@/assets/Utils'
 
 type ContentFilterProfileType = {
@@ -607,7 +607,10 @@ type ContentFilterProfileType = {
 
 export default defineComponent({
   name: 'ContentFilterEditor',
-  components: {AutocompleteInput},
+  components: {
+    AutocompleteInput,
+    TagAutocompleteInput,
+  },
   props: {
     selectedDoc: Object,
     selectedBranch: String,
@@ -707,10 +710,6 @@ export default defineComponent({
     },
 
     tagsInvalid(): boolean {
-      const doc = this.localDoc
-      if (!doc) {
-        return true
-      }
       const activeValid = this.localDoc.active?.length > 0
       const reportValid = this.localDoc.report?.length > 0
       const ignoreValid = this.localDoc.ignore?.length > 0

--- a/src/doc-editors/ContentFilterRulesEditor.vue
+++ b/src/doc-editors/ContentFilterRulesEditor.vue
@@ -86,7 +86,7 @@
                            v-model="selectedDocTags"
                            @change="emitDocUpdate"/>
                   </div>
-                  <div class="is-size-7">
+                  <div class="is-size-7 document-automatic-tags">
                     Automatic Tags:
                     <div v-html="automaticTags"></div>
                   </div>
@@ -161,16 +161,13 @@ export default defineComponent({
 
     automaticTags(): string {
       const rule = this.localDoc
-      if (!rule || !rule.id) {
-        return ''
-      }
-      const ruleTag = `cf-rule-id:${rule.id?.replace(/ /g, '-')}`
+      const ruleTag = `cf-rule-id:${rule.id?.replace(/ /g, '-') || ''}`
       const ruleTagElement = this.createTagElement(ruleTag)
       const riskTag = `cf-rule-risk:${rule.risk}`
       const riskTagElement = this.createTagElement(riskTag)
-      const categoryTag = `cf-rule-category:${rule.category?.replace(/ /g, '-')}`
+      const categoryTag = `cf-rule-category:${rule.category?.replace(/ /g, '-') || ''}`
       const categoryTagElement = this.createTagElement(categoryTag)
-      const subcategoryTag = `cf-rule-subcategory:${rule.subcategory?.replace(/ /g, '-')}`
+      const subcategoryTag = `cf-rule-subcategory:${rule.subcategory?.replace(/ /g, '-') || ''}`
       const subcategoryTagElement = this.createTagElement(subcategoryTag)
       return `${ruleTagElement}${riskTagElement}${categoryTagElement}${subcategoryTagElement}`
     },

--- a/src/doc-editors/FlowControlPolicyEditor.vue
+++ b/src/doc-editors/FlowControlPolicyEditor.vue
@@ -396,10 +396,6 @@ export default defineComponent({
       return _.cloneDeep(this.selectedDoc as FlowControlPolicy)
     },
 
-    pickType(val: IncludeExcludeType[]): IncludeExcludeType[] {
-      return val
-    },
-
     duplicateTags(): Dictionary<string> {
       const doc = this.localDoc
       const allTags = _.concat(doc['include'], doc['exclude'])

--- a/src/doc-editors/GlobalFilterListEditor.vue
+++ b/src/doc-editors/GlobalFilterListEditor.vue
@@ -63,7 +63,7 @@
             <div class="field">
               <label class="label is-small">Tags</label>
               <div class="control"
-                      data-qa="tag-input">
+                   data-qa="tag-input">
                 <tag-autocomplete-input :initial-tag="selectedDocTags"
                                         :selection-type="'multiple'"
                                         @tag-changed="selectedDocTags = $event">
@@ -151,7 +151,7 @@ import ResponseAction from '@/components/ResponseAction.vue'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import EntriesRelationList from '@/components/EntriesRelationList.vue'
 import {defineComponent} from 'vue'
-import {Category, Relation, GlobalFilter, GlobalFilterSection, GlobalFilterSectionEntry} from '@/types'
+import {Category, GlobalFilter, GlobalFilterSection, GlobalFilterSectionEntry, Relation} from '@/types'
 import {AxiosResponse} from 'axios'
 import DateTimeUtils from '@/assets/DateTimeUtils'
 
@@ -184,9 +184,9 @@ export default defineComponent({
 
   computed: {
     sectionsEntriesDisplay(): string {
-      const sectionsCounter = (this.localDoc?.rule?.sections?.length !== 1) ? 'sections' : 'section'
+      const sectionsCounter = (this.localDoc.rule?.sections?.length !== 1) ? 'sections' : 'section'
       const entriesCounter = (this.localDocTotalEntries !== 1) ? 'entries' : 'entry'
-      const sectionsLength = this.localDoc?.rule?.sections?.length
+      const sectionsLength = this.localDoc.rule?.sections?.length
       return `${sectionsLength} ${sectionsCounter}\t|\t${this.localDocTotalEntries} ${entriesCounter}`
     },
 
@@ -223,20 +223,20 @@ export default defineComponent({
 
     localDocTotalEntries(): number {
       let totalEntries = 0
-      if (this.localDoc?.rule?.sections?.length) {
+      if (this.localDoc.rule?.sections?.length) {
         totalEntries = _.sumBy(this.localDoc.rule.sections, (section: GlobalFilterSection) => {
-          return section.entries?.length
+          return section.entries?.length || 0
         })
       }
       return totalEntries
     },
 
     formattedModifiedDate(): string {
-      return DateTimeUtils.isoToNowCuriefenseFormat(this.localDoc?.mdate)
+      return DateTimeUtils.isoToNowCuriefenseFormat(this.localDoc.mdate)
     },
 
     fullFormattedModifiedDate(): string {
-      return DateTimeUtils.isoToNowFullCuriefenseFormat(this.localDoc?.mdate)
+      return DateTimeUtils.isoToNowFullCuriefenseFormat(this.localDoc.mdate)
     },
   },
 
@@ -311,7 +311,10 @@ export default defineComponent({
         })
       }
       const url = this.localDoc.source
-      RequestsUtils.sendRequest({methodName: 'GET', url: `tools/fetch?url=${url}`}).then((response: AxiosResponse) => {
+      RequestsUtils.sendRequest({
+        methodName: 'GET',
+        url: `tools/fetch?url=${url}`,
+      }).then((response: AxiosResponse) => {
         const data = response.data
         let entries: GlobalFilterSectionEntry[]
         const convertedData = data as GlobalFilter

--- a/src/doc-editors/RateLimitsEditor.vue
+++ b/src/doc-editors/RateLimitsEditor.vue
@@ -256,10 +256,10 @@
                     </div>
                   </td>
                   <td>
-                    {{ newSecurityPolicyConnectionData.map?.id }}
+                    {{ newSecurityPolicyConnectionData.map.id }}
                   </td>
                   <td>
-                    {{ newSecurityPolicyConnectionData.map?.match }}
+                    {{ newSecurityPolicyConnectionData.map.match }}
                   </td>
                   <td>
                     <div class="select is-small">
@@ -450,14 +450,14 @@ export default defineComponent({
 
     newSecurityPolicyConnectionEntries(): SecurityPolicyEntryMatch[] {
       const securityPolicy = this.newSecurityPolicyConnections.find((securityPolicy) => {
-        return securityPolicy.id === this.newSecurityPolicyConnectionData.map?.id
+        return securityPolicy.id === this.newSecurityPolicyConnectionData.map.id
       })
-      return securityPolicy?.map?.filter((securityPolicyEntry) => {
+      return securityPolicy.map.filter((securityPolicyEntry) => {
         return !securityPolicyEntry.limit_ids.includes(this.localDoc.id)
       })
     },
   },
-  emits: ['update:selectedDoc'],
+  emits: ['update:selectedDoc', 'go-to-route'],
   methods: {
     emitDocUpdate() {
       this.$emit('update:selectedDoc', this.localDoc)
@@ -578,7 +578,7 @@ export default defineComponent({
     },
 
     addNewSecurityPolicyConnection() {
-      const id = this.newSecurityPolicyConnectionData.map?.id
+      const id = this.newSecurityPolicyConnectionData.map.id
       const entryMatch = this.newSecurityPolicyConnectionEntries[this.newSecurityPolicyConnectionData.entryIndex].match
       const methodName = 'PUT'
       const selectedDocType = 'securitypolicies'
@@ -662,7 +662,7 @@ export default defineComponent({
     },
 
     referToSecurityPolicy(id: string) {
-      this.$router.push(`/config/${this.selectedBranch}/securitypolicies/${id}`)
+      this.$emit('go-to-route', `/config/${this.selectedBranch}/securitypolicies/${id}`)
     },
   },
   created() {

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -408,7 +408,7 @@ export default defineComponent({
       return this.localDoc.map.length > 1 && !isDefaultPath
     },
   },
-
+  emits: ['update:selectedDoc', 'form-invalid', 'go-to-route'],
   methods: {
     emitDocUpdate(): void {
       this.$emit('update:selectedDoc', this.localDoc)
@@ -433,7 +433,7 @@ export default defineComponent({
     // },
 
     isSelectedDomainMatchValid(): boolean {
-      const newDomainMatch = this.localDoc.match?.trim()
+      const newDomainMatch = this.localDoc.match.trim()
       const isDomainMatchEmpty = newDomainMatch === ''
       const isDomainMatchDuplicate = this.domainNames.includes(
           newDomainMatch,
@@ -445,7 +445,7 @@ export default defineComponent({
     },
 
     isSelectedMapEntryMatchValid(index: number): boolean {
-      const newMapEntryMatch = this.localDoc.map[index]?.match.trim() || ''
+      const newMapEntryMatch = this.localDoc.map[index].match.trim() || ''
       let isValid = newMapEntryMatch.startsWith('/')
       if (isValid) {
         const isMapEntryMatchEmpty = newMapEntryMatch === ''
@@ -554,7 +554,7 @@ export default defineComponent({
 
     referToRateLimit() {
       this.$emit('form-invalid', false)
-      this.$router.push(`/config/${this.selectedBranch}/ratelimits`)
+      this.$emit('go-to-route', `/config/${this.selectedBranch}/ratelimits`)
     },
 
     contentfilteracllimitProfileNames() {

--- a/src/doc-editors/__tests__/ContentFilterRulesEditor.spec.ts
+++ b/src/doc-editors/__tests__/ContentFilterRulesEditor.spec.ts
@@ -1,9 +1,8 @@
 // @ts-nocheck
 import ContentFilterRulesEditor from '@/doc-editors/ContentFilterRulesEditor.vue'
 import {beforeEach, describe, expect, test} from '@jest/globals'
-import {shallowMount} from '@vue/test-utils'
+import {shallowMount, VueWrapper} from '@vue/test-utils'
 import {ContentFilterRule} from '@/types'
-import {VueWrapper} from '@vue/test-utils'
 
 describe('ContentFilterRulesEditor.vue', () => {
   let docs: ContentFilterRule[]
@@ -61,84 +60,183 @@ describe('ContentFilterRulesEditor.vue', () => {
       const element = wrapper.find('.document-subcategory').element as HTMLInputElement
       expect(element.value).toEqual(docs[0].subcategory)
     })
+
+    test('should have correct tags displayed - multiple', () => {
+      const wantedTags = ['test1', 'test2']
+      docs[0].tags = wantedTags
+      wrapper = shallowMount(ContentFilterRulesEditor, {
+        props: {
+          selectedDoc: docs[0],
+        },
+      })
+      const element = wrapper.find('.document-tags').element as HTMLInputElement
+      expect(element.value).toEqual(wantedTags.join(' '))
+    })
+
+    test('should have correct tags displayed - single', () => {
+      const wantedTag = 'test1'
+      docs[0].tags = [wantedTag]
+      wrapper = shallowMount(ContentFilterRulesEditor, {
+        props: {
+          selectedDoc: docs[0],
+        },
+      })
+      const element = wrapper.find('.document-tags').element as HTMLInputElement
+      expect(element.value).toEqual(wantedTag)
+    })
+
+    test('should have correct tags displayed - empty', () => {
+      docs[0].tags = []
+      wrapper = shallowMount(ContentFilterRulesEditor, {
+        props: {
+          selectedDoc: docs[0],
+        },
+      })
+      const element = wrapper.find('.document-tags').element as HTMLInputElement
+      expect(element.value).toEqual('')
+    })
+
+    test('should have correct automatic tags displayed', () => {
+      const element = wrapper.find('.document-automatic-tags').element as HTMLDivElement
+      expect(element.innerHTML).toContain(`cf-rule-id:${docs[0].id.replace(/ /g, '-')}`)
+      expect(element.innerHTML).toContain(`cf-rule-risk:${docs[0].risk}`)
+      expect(element.innerHTML).toContain(`cf-rule-category:${docs[0].category.replace(/ /g, '-')}`)
+      expect(element.innerHTML).toContain(`cf-rule-subcategory:${docs[0].subcategory.replace(/ /g, '-')}`)
+    })
+
+    test('should have empty automatic tags displayed - empty id', () => {
+      delete docs[0].id
+      wrapper = shallowMount(ContentFilterRulesEditor, {
+        props: {
+          selectedDoc: docs[0],
+        },
+      })
+      const element = wrapper.find('.document-automatic-tags').element as HTMLDivElement
+      expect(element.innerHTML).toContain('cf-rule-id:\n')
+    })
+
+    test('should have empty automatic tags displayed - empty category', () => {
+      delete docs[0].category
+      wrapper = shallowMount(ContentFilterRulesEditor, {
+        props: {
+          selectedDoc: docs[0],
+        },
+      })
+      const element = wrapper.find('.document-automatic-tags').element as HTMLDivElement
+      expect(element.innerHTML).toContain('cf-rule-category:\n')
+    })
+
+    test('should have empty automatic tags displayed - empty subcategory', () => {
+      delete docs[0].subcategory
+      wrapper = shallowMount(ContentFilterRulesEditor, {
+        props: {
+          selectedDoc: docs[0],
+        },
+      })
+      const element = wrapper.find('.document-automatic-tags').element as HTMLDivElement
+      expect(element.innerHTML).toContain('cf-rule-subcategory:\n')
+    })
   })
 
-  test('should emit doc update when name input changes', async () => {
-    const wantedName = 'new name'
-    const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
-    wantedEmit.name = wantedName
-    const element = wrapper.find('.document-name')
-    await element.setValue(wantedName)
-    await element.trigger('change')
-    expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
-    expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
-  })
+  describe('form data change', () => {
+    test('should emit doc update when name input changes', async () => {
+      const wantedName = 'new name'
+      const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
+      wantedEmit.name = wantedName
+      const element = wrapper.find('.document-name')
+      await element.setValue(wantedName)
+      await element.trigger('change')
+      expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
+      expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
+    })
 
-  test('should emit doc update when description input changes', async () => {
-    const wanteddescription = 'new description'
-    const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
-    wantedEmit.description = wanteddescription
-    const element = wrapper.find('.document-description')
-    element.setValue(wanteddescription)
-    await element.trigger('change')
-    expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
-    expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
-  })
+    test('should emit doc update when description input changes', async () => {
+      const wanteddescription = 'new description'
+      const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
+      wantedEmit.description = wanteddescription
+      const element = wrapper.find('.document-description')
+      element.setValue(wanteddescription)
+      await element.trigger('change')
+      expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
+      expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
+    })
 
-  test('should emit doc update when category input changes', async () => {
-    const wantedCategory = 'new category'
-    const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
-    wantedEmit.category = wantedCategory
-    const element = wrapper.find('.document-category')
-    element.setValue(wantedCategory)
-    await element.trigger('change')
-    expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
-    expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
-  })
+    test('should emit doc update when category input changes', async () => {
+      const wantedCategory = 'new category'
+      const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
+      wantedEmit.category = wantedCategory
+      const element = wrapper.find('.document-category')
+      element.setValue(wantedCategory)
+      await element.trigger('change')
+      expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
+      expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
+    })
 
-  test('should emit doc update when subcategory input changes', async () => {
-    const wantedSubcategory = 'new category'
-    const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
-    wantedEmit.subcategory = wantedSubcategory
-    const element = wrapper.find('.document-subcategory')
-    element.setValue(wantedSubcategory)
-    await element.trigger('change')
-    expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
-    expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
-  })
+    test('should emit doc update when subcategory input changes', async () => {
+      const wantedSubcategory = 'new category'
+      const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
+      wantedEmit.subcategory = wantedSubcategory
+      const element = wrapper.find('.document-subcategory')
+      element.setValue(wantedSubcategory)
+      await element.trigger('change')
+      expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
+      expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
+    })
 
-  test('should emit doc update when risk level input changes', async () => {
-    const wantedRisk = 3
-    const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
-    wantedEmit.risk = wantedRisk
-    const selection = wrapper.find('.risk-level-selection')
-    const options = selection.findAll('option')
-    selection.setValue(options.at(2).element.value)
-    // options.at(2).setSelected() // index => value: 0 => 1, 1 => 2, 2 => 3
-    await selection.trigger('change')
-    expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
-    expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
-  })
+    test('should emit doc update when risk level input changes', async () => {
+      const wantedRisk = 3
+      const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
+      wantedEmit.risk = wantedRisk
+      const selection = wrapper.find('.risk-level-selection')
+      const options = selection.findAll('option')
+      selection.setValue(options.at(2).element.value)
+      // options.at(2).setSelected() // index => value: 0 => 1, 1 => 2, 2 => 3
+      await selection.trigger('change')
+      expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
+      expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
+    })
 
-  test('should emit doc update when log message input changes', async () => {
-    const wantedMessage = 'This is a message in the logs'
-    const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
-    wantedEmit.msg = wantedMessage
-    const element = wrapper.find('.document-msg')
-    element.setValue(wantedMessage)
-    await element.trigger('change')
-    expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
-    expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
-  })
+    test('should emit doc update when log message input changes', async () => {
+      const wantedMessage = 'This is a message in the logs'
+      const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
+      wantedEmit.msg = wantedMessage
+      const element = wrapper.find('.document-msg')
+      element.setValue(wantedMessage)
+      await element.trigger('change')
+      expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
+      expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
+    })
 
-  test('should emit doc update when operand input changes', async () => {
-    const wantedOperand = '\\s(and|or)\\s+["\']\\w+["\']\\s+.*between\\s.*["\']\\w+["\']\\s+and\\s+["\']\\w+.*'
-    const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
-    wantedEmit.operand = wantedOperand
-    const element = wrapper.find('.document-operand')
-    element.setValue(wantedOperand)
-    await element.trigger('change')
-    expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
-    expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
+    test('should emit doc update when operand input changes', async () => {
+      const wantedOperand = '\\s(and|or)\\s+["\']\\w+["\']\\s+.*between\\s.*["\']\\w+["\']\\s+and\\s+["\']\\w+.*'
+      const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
+      wantedEmit.operand = wantedOperand
+      const element = wrapper.find('.document-operand')
+      element.setValue(wantedOperand)
+      await element.trigger('change')
+      expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
+      expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
+    })
+
+    test('should emit doc update when tags input changes - single', async () => {
+      const wantedTag = 'test1'
+      const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
+      wantedEmit.tags = [wantedTag]
+      const element = wrapper.find('.document-tags')
+      element.setValue(wantedTag)
+      await element.trigger('change')
+      expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
+      expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
+    })
+
+    test('should emit doc update when tags input changes - multiple', async () => {
+      const wantedEmit = JSON.parse(JSON.stringify(docs[0]))
+      wantedEmit.tags = []
+      const element = wrapper.find('.document-tags')
+      element.setValue('')
+      await element.trigger('change')
+      expect(wrapper.emitted('update:selectedDoc')).toBeTruthy()
+      expect(wrapper.emitted('update:selectedDoc')[0]).toEqual([wantedEmit])
+    })
   })
 })

--- a/src/doc-editors/__tests__/GlobalFilterListEditor.spec.ts
+++ b/src/doc-editors/__tests__/GlobalFilterListEditor.spec.ts
@@ -71,6 +71,9 @@ describe('GlobalFilterListEditor.vue', () => {
           }],
       },
     }]
+    jest.spyOn(axios, 'get').mockImplementation(() => {
+      return Promise.resolve({data: {}})
+    })
     wrapper = shallowMount(GlobalFilterListEditor, {
       props: {
         selectedDoc: docs[0],

--- a/src/doc-editors/__tests__/GlobalFilterListEditor.spec.ts
+++ b/src/doc-editors/__tests__/GlobalFilterListEditor.spec.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import GlobalFilterListEditor from '@/doc-editors/GlobalFilterListEditor.vue'
 import {beforeEach, describe, expect, jest, test} from '@jest/globals'
-import {shallowMount, VueWrapper} from '@vue/test-utils'
+import {mount, shallowMount, VueWrapper} from '@vue/test-utils'
 import {GlobalFilter, GlobalFilterSectionEntry} from '@/types'
 import ResponseAction from '@/components/ResponseAction.vue'
 import TagsAutocompleteInput from '@/components/TagAutocompleteInput.vue'
@@ -138,7 +138,20 @@ describe('GlobalFilterListEditor.vue', () => {
         expect(display.text()).toContain('0 sections')
       })
 
-      test('should display correct zero amount of entries', () => {
+      test('should display correct zero amount of entries - not an array', () => {
+        docs[0].rule.sections = [
+          {'relation': 'OR', 'entries': null},
+        ]
+        wrapper = shallowMount(GlobalFilterListEditor, {
+          props: {
+            selectedDoc: docs[0],
+          },
+        })
+        const display = wrapper.find('.sections-entries-display')
+        expect(display.text()).toContain('0 entries')
+      })
+
+      test('should display correct zero amount of entries - length zero', () => {
         docs[0].rule.sections = [
           {'relation': 'OR', 'entries': []},
         ]
@@ -218,6 +231,39 @@ describe('GlobalFilterListEditor.vue', () => {
     test('should have entries relation component with editable false prop', () => {
       const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
       expect(entriesRelationListComponent.props('editable')).toBeFalsy()
+    })
+  })
+
+  describe('selected doc change', () => {
+    let cancelAllEntriesSpy
+    beforeEach(() => {
+      const basicDocument = {
+        'id': '__default__',
+        'name': 'default entry',
+      }
+      wrapper = mount(GlobalFilterListEditor, {
+        props: {
+          selectedDoc: basicDocument,
+        },
+      })
+      cancelAllEntriesSpy = jest.spyOn(wrapper.vm.$refs.entriesRelationList, 'cancelAllEntries')
+    })
+
+    test('should cancel all new entries relation filter if selectedDoc updates - new ID', async () => {
+      await wrapper.setProps({selectedDoc: docs[0]})
+      expect(cancelAllEntriesSpy).toHaveBeenCalled()
+    })
+
+    test('should cancel all new entries relation filter if selectedDoc updates - new empty', async () => {
+      await wrapper.setProps({selectedDoc: {}})
+      expect(cancelAllEntriesSpy).toHaveBeenCalled()
+    })
+
+    test('should cancel all new entries relation filter if selectedDoc updates - old empty', async () => {
+      await wrapper.setProps({selectedDoc: {}})
+      jest.clearAllMocks()
+      await wrapper.setProps({selectedDoc: docs[0]})
+      expect(cancelAllEntriesSpy).toHaveBeenCalled()
     })
   })
 
@@ -619,7 +665,7 @@ describe('GlobalFilterListEditor.vue', () => {
         [
           'ip',
           '203.208.60.0/24',
-          'Crawler',
+          null,
         ],
         [
           'ip',
@@ -672,7 +718,7 @@ describe('GlobalFilterListEditor.vue', () => {
         [
           'asn',
           'as34109',
-          'spam',
+          null,
         ],
         [
           'asn',
@@ -808,7 +854,7 @@ describe('GlobalFilterListEditor.vue', () => {
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
 
-    test('should update entries relation component with correct data - global filter structure', async () => {
+    test('should update entries relation component with correct data - global filter', async () => {
       const globalFilter: GlobalFilter = {
         'id': 'xlbp148c',
         'name': 'API Discovery',
@@ -841,24 +887,92 @@ describe('GlobalFilterListEditor.vue', () => {
       expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
     })
 
-    test('should not update entries relation component when no data found', async () => {
+    test('should not update entries relation component with correct data - global filter - no entries', async () => {
       const wantedData: GlobalFilter['rule'] = docs[0].rule
       resolveData = {
         data: {
-          'type': 'acl',
-          'name': 'Crawler example',
-          'id': 'example_id',
+          'id': 'xlbp148c',
+          'name': 'API Discovery',
+          'source': 'self-managed',
+          'mdate': '2020-05-23T00:04:41',
+          'description': 'Tag API Requests',
           'active': true,
-          'mdate': '2020-11-04 07:54:27.417791',
-          'source': 'https://example.com',
-          'description': 'some example crawlers',
-          'entries_relation': 'OR',
-          'tags': [
-            'allowlist',
-            'crawler',
-          ],
-          'entries': [],
+          'tags': ['api', 'okay'],
+          'action': {
+            'type': 'monitor',
+            'params': {},
+          },
+          'rule': {
+            'relation': 'OR',
+            'sections': [],
+          },
         },
+      }
+      const button = wrapper.find('.update-now-button')
+      await button.trigger('click')
+      wrapper.vm.$forceUpdate()
+      await nextTick()
+      const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
+      expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
+    })
+
+    test('should not update entries relation component with correct data - global filter - no sections', async () => {
+      const wantedData: GlobalFilter['rule'] = docs[0].rule
+      resolveData = {
+        data: {
+          'id': 'xlbp148c',
+          'name': 'API Discovery',
+          'source': 'self-managed',
+          'mdate': '2020-05-23T00:04:41',
+          'description': 'Tag API Requests',
+          'active': true,
+          'tags': ['api', 'okay'],
+          'action': {
+            'type': 'monitor',
+            'params': {},
+          },
+          'rule': {
+            'relation': 'OR',
+          },
+        },
+      }
+      const button = wrapper.find('.update-now-button')
+      await button.trigger('click')
+      wrapper.vm.$forceUpdate()
+      await nextTick()
+      const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
+      expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
+    })
+
+    test('should not update entries relation component with correct data - global filter - no rule', async () => {
+      const wantedData: GlobalFilter['rule'] = docs[0].rule
+      resolveData = {
+        data: {
+          'id': 'xlbp148c',
+          'name': 'API Discovery',
+          'source': 'self-managed',
+          'mdate': '2020-05-23T00:04:41',
+          'description': 'Tag API Requests',
+          'active': true,
+          'tags': ['api', 'okay'],
+          'action': {
+            'type': 'monitor',
+            'params': {},
+          },
+        },
+      }
+      const button = wrapper.find('.update-now-button')
+      await button.trigger('click')
+      wrapper.vm.$forceUpdate()
+      await nextTick()
+      const entriesRelationListComponent = wrapper.findComponent(EntriesRelationList)
+      expect(entriesRelationListComponent.props('rule')).toEqual(wantedData)
+    })
+
+    test('should not update entries relation component when no data found', async () => {
+      const wantedData: GlobalFilter['rule'] = docs[0].rule
+      resolveData = {
+        data: null,
       }
       const button = wrapper.find('.update-now-button')
       await button.trigger('click')

--- a/src/doc-editors/__tests__/RateLimitsEditor.spec.ts
+++ b/src/doc-editors/__tests__/RateLimitsEditor.spec.ts
@@ -470,8 +470,8 @@ describe('RateLimitsEditor.vue', () => {
       const connectedSecurityPoliciesEntryRow = wrapper.findAll('.connected-entry-row').at(0)
       const referralButton = connectedSecurityPoliciesEntryRow.find('.security-policy-referral-button')
       await referralButton.trigger('click')
-      expect(mockRouter.push).toHaveBeenCalledTimes(1)
-      expect(mockRouter.push).toHaveBeenCalledWith(wantedRoute)
+      expect(wrapper.emitted('go-to-route')).toBeTruthy()
+      expect(wrapper.emitted('go-to-route')[0]).toEqual([wantedRoute])
     })
 
     test('should show the new connection row when `+` button is clicked', async () => {

--- a/src/doc-editors/__tests__/SecurityPoliciesEditor.spec.ts
+++ b/src/doc-editors/__tests__/SecurityPoliciesEditor.spec.ts
@@ -709,8 +709,8 @@ describe('SecurityPoliciesEditor.vue', () => {
       await nextTick()
       const referralButton = entryRateLimitsTable.find('.rate-limit-referral-button')
       await referralButton.trigger('click')
-      expect(mockRouter.push).toHaveBeenCalledTimes(1)
-      expect(mockRouter.push).toHaveBeenCalledWith(`/config/${selectedBranch}/ratelimits`)
+      expect(wrapper.emitted('go-to-route')).toBeTruthy()
+      expect(wrapper.emitted('go-to-route')[0]).toEqual([`/config/${selectedBranch}/ratelimits`])
     })
   })
 

--- a/src/views/CurieDBEditor.vue
+++ b/src/views/CurieDBEditor.vue
@@ -327,7 +327,7 @@ export default defineComponent({
     },
 
     isSelectedNamespaceNewNameValid(): boolean {
-      const newName = this.namespaceNameInput?.trim()
+      const newName = this.namespaceNameInput.trim()
       const isNamespaceNameEmpty = newName === ''
       const isNamespaceNameDuplicate = this.databases.includes(newName) ? this.selectedNamespace !== newName : false
       return !isNamespaceNameEmpty && !isNamespaceNameDuplicate
@@ -359,7 +359,7 @@ export default defineComponent({
     async loadDatabases() {
       this.setLoadingDocStatus(true)
       await RequestsUtils.sendRequest({methodName: 'GET', url: 'db/'}).then((response: AxiosResponse<string[]>) => {
-        this.databases = response?.data || []
+        this.databases = response?.data?.length ? response.data : []
         console.log('Databases: ', this.databases)
         this.loadFirstNamespace()
       })
@@ -367,7 +367,7 @@ export default defineComponent({
     },
 
     loadFirstNamespace() {
-      const namespace = this.databases?.[0]
+      const namespace = this.databases[0]
       if (namespace) {
         this.loadNamespace(namespace)
       } else {
@@ -502,9 +502,6 @@ export default defineComponent({
     },
 
     async addNewKey(newKey?: string, newValue?: string) {
-      if (!this.selectedNamespace) {
-        return
-      }
       this.isNewKeyLoading = true
       if (!newKey) {
         newKey = Utils.generateUniqueEntityName('new key', this.namespaceKeys)
@@ -529,9 +526,6 @@ export default defineComponent({
     },
 
     downloadKey() {
-      if (!this.selectedKeyValue) {
-        return
-      }
       Utils.downloadFile(this.selectedKey, 'json', JSON.parse(this.selectedKeyValue))
     },
 
@@ -565,7 +559,7 @@ export default defineComponent({
       this.loadingGitlog = true
       const url = `db/${this.selectedNamespace}/k/${this.selectedKey}/v/`
       const response = await RequestsUtils.sendRequest({methodName: 'GET', url})
-      this.gitLog = response?.data
+      this.gitLog = response?.data || []
       this.loadingGitlog = false
     },
 

--- a/src/views/DocumentEditor.vue
+++ b/src/views/DocumentEditor.vue
@@ -163,6 +163,7 @@
             v-model:docs="docs"
             :apiPath="documentAPIPath"
             @form-invalid="isDocumentInvalid = $event"
+            @go-to-route="goToRoute($event)"
             ref="currentComponent">
         </component>
         <hr/>
@@ -299,7 +300,7 @@ export default defineComponent({
 
     selectedDoc: {
       get(): Document {
-        return this.docs?.[this.selectedDocIndex]
+        return this.docs[this.selectedDocIndex]
       },
       set(newDoc: Document): void {
         this.docs[this.selectedDocIndex] = newDoc
@@ -339,11 +340,14 @@ export default defineComponent({
 
   methods: {
 
-    goToRoute() {
-      const currentRoute = `/config/${this.selectedBranch}/${this.selectedDocType}/${this.selectedDocID}`
-      if (this.$route.path !== currentRoute) {
-        console.log('Switching document, new document path: ' + currentRoute)
-        this.$router.push(currentRoute)
+    async goToRoute(newRoute?: string) {
+      if (!newRoute) {
+        newRoute = `/config/${this.selectedBranch}/${this.selectedDocType}/${this.selectedDocID}`
+      }
+      if (this.$route.path !== newRoute) {
+        console.log('Switching document, new document path: ' + newRoute)
+        await this.$router.push(newRoute)
+        await this.setSelectedDataFromRouteParams()
       }
     },
 
@@ -422,7 +426,7 @@ export default defineComponent({
           methodName: 'GET',
           url: `configs/${this.selectedBranch}/d/${this.selectedDocType}/e/${this.selectedDocID}/`,
         })
-        this.selectedDoc = response?.data
+        this.selectedDoc = response?.data || this.selectedDoc
       }
       this.setLoadingDocStatus(false)
     },

--- a/src/views/Publish.vue
+++ b/src/views/Publish.vue
@@ -213,7 +213,7 @@ export default defineComponent({
       const selectedBranch = _.find(this.configs, (conf) => {
         return conf.id === this.selectedBranchName
       })
-      this.gitLog = selectedBranch?.logs
+      this.gitLog = selectedBranch.logs
       this.selectedCommit = this.gitLog?.[0]?.version || null
     },
 
@@ -226,17 +226,15 @@ export default defineComponent({
 
     setDefaultBuckets() {
       this.selectedBucketNames = []
-      if (this.publishInfo?.branch_buckets?.length) {
-        const bucketList = _.find(this.publishInfo.branch_buckets, (list) => {
-          return list.name === this.selectedBranchName
-        })
-        if (bucketList) {
-          this.selectedBucketNames = _.cloneDeep(_.filter(bucketList.buckets, (bucket) => {
-            return _.find(this.publishInfo.buckets, (publishInfoBucket) => {
-              return publishInfoBucket.name === bucket
-            })
-          }))
-        }
+      const bucketList = _.find(this.publishInfo.branch_buckets, (list) => {
+        return list.name === this.selectedBranchName
+      })
+      if (bucketList) {
+        this.selectedBucketNames = _.cloneDeep(_.filter(bucketList.buckets, (bucket) => {
+          return _.find(this.buckets, (publishInfoBucket) => {
+            return publishInfoBucket.name === bucket
+          })
+        }))
       }
     },
 
@@ -246,7 +244,7 @@ export default defineComponent({
         url: `db/system/k/publishinfo/`,
         failureMessage: 'Failed while attempting to load publish info',
       }).then((response: AxiosResponse) => {
-        this.publishInfo = response?.data
+        this.publishInfo = {...this.publishInfo, ...response.data}
         this.setDefaultBuckets()
       })
     },
@@ -263,7 +261,10 @@ export default defineComponent({
     loadConfigs() {
       // store configs
       RequestsUtils.sendRequest({methodName: 'GET', url: 'configs/'}).then((response: AxiosResponse<Branch[]>) => {
-        this.configs = response?.data
+        this.configs = response?.data || []
+        if (!this.configs.length) {
+          return
+        }
         // pick first branch name as selected
         this.selectedBranchName = this.branchNames[0]
         this.loadBranchLogs()

--- a/src/views/VersionControl.vue
+++ b/src/views/VersionControl.vue
@@ -219,7 +219,7 @@ export default defineComponent({
     },
 
     isSelectedBranchForkNameValid(): boolean {
-      const newName = this.forkBranchName?.trim()
+      const newName = this.forkBranchName.trim()
       const isBranchNameEmpty = newName === ''
       const isBranchNameContainsSpaces = newName.includes(' ')
       const isBranchNameDuplicate = this.branchNames.includes(newName)
@@ -227,7 +227,7 @@ export default defineComponent({
     },
 
     isSelectedBranchDeleteNameValid(): boolean {
-      const newName = this.deleteBranchName?.trim()
+      const newName = this.deleteBranchName.trim()
       return newName === this.selectedBranch
     },
 
@@ -260,8 +260,7 @@ export default defineComponent({
     async loadConfigs(activeBranch?: string) {
       // store configs
       const response = await RequestsUtils.sendRequest({methodName: 'GET', url: 'configs/'})
-      const configs = response?.data
-      this.configs = configs
+      this.configs = response?.data || []
       if (!activeBranch) {
         // pick first branch name as selected if not given active branch
         this.selectedBranch = this.branchNames[0]
@@ -271,19 +270,20 @@ export default defineComponent({
         })
       }
       // counters
-      this.commits = _.sum(_.map(_.map(configs, 'logs'), (logs) => {
+      this.commits = _.sum(_.map(_.map(this.configs, 'logs'), (logs) => {
         return _.size(logs)
       }))
-      this.branches = _.size(configs)
+      this.branches = _.size(this.configs)
       console.log('config counters', this.branches, this.commits)
     },
 
     async loadSelectedBranchData() {
       this.isDownloadLoading = true
-      this.selectedBranchData = (await RequestsUtils.sendRequest({
+      const response = await RequestsUtils.sendRequest({
         methodName: 'GET',
         url: `configs/${this.selectedBranch}/`,
-      }))?.data
+      })
+      this.selectedBranchData = response?.data
       this.isDownloadLoading = false
     },
 

--- a/src/views/__tests__/Publish.spec.ts
+++ b/src/views/__tests__/Publish.spec.ts
@@ -185,8 +185,34 @@ describe('Publish.vue', () => {
     })
   })
 
-  test('should display no version and 0 buckets if no logs are present', async () => {
+  test('should display no version and 0 buckets if no logs are present - empty array', async () => {
     gitData[0].logs = []
+    wrapper = mount(Publish)
+    const versionDisplay = wrapper.find('.version-display')
+    expect(versionDisplay.text()).toEqual(`Version:`)
+    const bucketsDisplay = wrapper.find('.buckets-display')
+    expect(bucketsDisplay.text()).toEqual('Buckets: 0')
+  })
+
+  test('should display no version and 0 buckets if no logs are present - property does not exist', async () => {
+    delete gitData[0].logs
+    wrapper = mount(Publish)
+    const versionDisplay = wrapper.find('.version-display')
+    expect(versionDisplay.text()).toEqual(`Version:`)
+    const bucketsDisplay = wrapper.find('.buckets-display')
+    expect(bucketsDisplay.text()).toEqual('Buckets: 0')
+  })
+
+  test('should display no version and 0 buckets if no logs are present - version does not exist', async () => {
+    gitData[0].logs = [{
+      'date': '2020-11-08T21:31:41+01:00',
+      'parents': [
+        '16379cdf39501574b4a2f5a227b82a4454884b84',
+      ],
+      'message': 'Create config [master]\n',
+      'email': 'curiefense@reblaze.com',
+      'author': 'Curiefense API',
+    }]
     wrapper = mount(Publish)
     const versionDisplay = wrapper.find('.version-display')
     expect(versionDisplay.text()).toEqual(`Version:`)
@@ -220,6 +246,82 @@ describe('Publish.vue', () => {
     // allow all requests to finish
     const gitBranches = wrapper.find('.buckets-display')
     expect(gitBranches.text()).toEqual('Buckets: 1')
+  })
+
+  test('should not throw errors if no branches exist - null response', (done) => {
+    try {
+      jest.spyOn(axios, 'get').mockImplementation((path) => {
+        if (path === '/conf/api/v2/configs/') {
+          return Promise.resolve(null)
+        }
+        if (path === `/conf/api/v2/db/system/k/publishinfo/`) {
+          return Promise.resolve({data: publishInfoData})
+        }
+        return Promise.resolve({data: {}})
+      })
+      wrapper = mount(Publish)
+      done()
+    } catch (err) {
+      expect(err).not.toBeDefined()
+      done()
+    }
+  })
+
+  test('should not throw errors if no branches exist - empty data', (done) => {
+    try {
+      jest.spyOn(axios, 'get').mockImplementation((path) => {
+        if (path === '/conf/api/v2/configs/') {
+          return Promise.resolve({data: []})
+        }
+        if (path === `/conf/api/v2/db/system/k/publishinfo/`) {
+          return Promise.resolve({data: publishInfoData})
+        }
+        return Promise.resolve({data: {}})
+      })
+      wrapper = mount(Publish)
+      done()
+    } catch (err) {
+      expect(err).not.toBeDefined()
+      done()
+    }
+  })
+
+  test('should not throw errors if no publish info exists', (done) => {
+    try {
+      jest.spyOn(axios, 'get').mockImplementation((path) => {
+        if (path === '/conf/api/v2/configs/') {
+          return Promise.resolve({data: gitData})
+        }
+        if (path === `/conf/api/v2/db/system/k/publishinfo/`) {
+          return Promise.resolve({data: {}})
+        }
+        return Promise.resolve({data: {}})
+      })
+      wrapper = mount(Publish)
+      done()
+    } catch (err) {
+      expect(err).not.toBeDefined()
+      done()
+    }
+  })
+
+  test('should not throw errors if no publish info exists', (done) => {
+    try {
+      jest.spyOn(axios, 'get').mockImplementation((path) => {
+        if (path === '/conf/api/v2/configs/') {
+          return Promise.resolve({data: gitData})
+        }
+        if (path === `/conf/api/v2/db/system/k/publishinfo/`) {
+          return Promise.resolve({data: {}})
+        }
+        return Promise.resolve({data: {}})
+      })
+      wrapper = mount(Publish)
+      done()
+    } catch (err) {
+      expect(err).not.toBeDefined()
+      done()
+    }
   })
 
   describe('commits table display', () => {

--- a/src/views/__tests__/VersionControl.spec.ts
+++ b/src/views/__tests__/VersionControl.spec.ts
@@ -356,6 +356,112 @@ describe('VersionControl.vue', () => {
     expect(downloadFileSpy).not.toHaveBeenCalled()
   })
 
+  test('should not throw errors if no branches exist - null response', (done) => {
+    try {
+      jest.spyOn(axios, 'get').mockImplementation((path) => {
+        if (path === '/conf/api/v2/configs/') {
+          return Promise.resolve(null)
+        }
+        return Promise.resolve({data: {}})
+      })
+      wrapper = mount(VersionControl)
+      done()
+    } catch (err) {
+      expect(err).not.toBeDefined()
+      done()
+    }
+  })
+
+  test('should not throw errors if no branches exist - empty data', (done) => {
+    try {
+      jest.spyOn(axios, 'get').mockImplementation((path) => {
+        if (path === '/conf/api/v2/configs/') {
+          return Promise.resolve({data: []})
+        }
+        return Promise.resolve({data: {}})
+      })
+      wrapper = mount(VersionControl)
+      done()
+    } catch (err) {
+      expect(err).not.toBeDefined()
+      done()
+    }
+  })
+
+  test('should not throw errors if no branch data exist - null response', (done) => {
+    try {
+      jest.spyOn(axios, 'get').mockImplementation((path) => {
+        if (path === '/conf/api/v2/configs/') {
+          return Promise.resolve({data: gitData})
+        }
+        if (path === '/conf/api/v2/configs/master/') {
+          return Promise.resolve(null)
+        }
+        return Promise.resolve({data: {}})
+      })
+      wrapper = mount(VersionControl)
+      done()
+    } catch (err) {
+      expect(err).not.toBeDefined()
+      done()
+    }
+  })
+
+  test('should not throw errors if no branch data exist - empty data', (done) => {
+    try {
+      jest.spyOn(axios, 'get').mockImplementation((path) => {
+        if (path === '/conf/api/v2/configs/') {
+          return Promise.resolve({data: gitData})
+        }
+        if (path === '/conf/api/v2/configs/master/') {
+          return Promise.resolve({data: null})
+        }
+        return Promise.resolve({data: {}})
+      })
+      wrapper = mount(VersionControl)
+      done()
+    } catch (err) {
+      expect(err).not.toBeDefined()
+      done()
+    }
+  })
+
+  test('should have an empty git log array if got no git log data from server - response null', () => {
+    jest.spyOn(axios, 'get').mockImplementation((path) => {
+      if (path === '/conf/api/v2/configs/') {
+        return Promise.resolve({data: gitData})
+      }
+      if (path === '/conf/api/v2/configs/master/') {
+        return Promise.resolve({data: gitData[0]})
+      }
+      if (path === '/conf/api/v2/configs/master/v/') {
+        return Promise.resolve(null)
+      }
+      return Promise.resolve({data: []})
+    })
+    wrapper = mount(VersionControl)
+    const gitHistory = wrapper.findComponent(GitHistory)
+    expect(gitHistory).toBeTruthy()
+  })
+
+  test('should have an empty git log array if got no git log data from server - data null', () => {
+    jest.spyOn(axios, 'get').mockImplementation((path) => {
+      if (path === '/conf/api/v2/configs/') {
+        return Promise.resolve({data: gitData})
+      }
+      if (path === '/conf/api/v2/configs/master/') {
+        return Promise.resolve({data: gitData[0]})
+      }
+      if (path === '/conf/api/v2/configs/master/v/') {
+        return Promise.resolve({data: null})
+      }
+      return Promise.resolve({data: []})
+    })
+    wrapper = mount(VersionControl)
+    const gitHistory = wrapper.findComponent(GitHistory)
+    expect(gitHistory).toBeTruthy()
+  })
+
   describe('fork branch', () => {
     let postSpy: any
     let originalError: any


### PR DESCRIPTION
Add unit tests for ContentFilterProfileEditor.vue
Add unit tests for ContentFilterRulesEditor.vue
Add unit tests for GlobalFilterListEditor.vue
Add unit tests for RateLimitsEditor.vue
Add unit tests for CurieDBEditor.vue
Add unit tests for DocumentEditor.vue
Add unit tests for Publish.vue
Add unit tests for VersionControl.vue
Fix some issues in these files
Remove some optional chaining that were not needed

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>