### PR TITLE
Change system to work with the new bootstrap data

### DIFF
--- a/src/assets/DatasetsUtils.ts
+++ b/src/assets/DatasetsUtils.ts
@@ -211,7 +211,7 @@ const newDocEntryFactory: { [key: string]: Function } = {
           'id': generateUUID2(),
           'match': '/',
           'name': 'default',
-          'acl_profile': '__default__',
+          'acl_profile': '__acldefault__',
           'content_filter_profile': '__default__',
           'acl_active': false,
           'content_filter_active': false,
@@ -344,7 +344,7 @@ const newOperationEntryFactory: { [key: string]: Function } = {
       'security_policy': '__default__',
       'routing_profile': '__default__',
       'proxy_template': '__default__',
-      'mobile_sdk': '__default__',
+      'mobile_sdk': '',
     }
   },
 
@@ -355,6 +355,7 @@ const newOperationEntryFactory: { [key: string]: Function } = {
       'description': 'New Routing Profile Description and Remarks',
       'locations': [
         {
+          'id': generateUUID2(),
           'path': '/',
           'backend_id': '__default__',
           'cloud_functions': [],

--- a/src/assets/__tests__/DatasetsUtils.spec.ts
+++ b/src/assets/__tests__/DatasetsUtils.spec.ts
@@ -87,7 +87,7 @@ describe('RequestsUtils.ts', () => {
       expect(document['match']).toEqual(`${document['id']}.example.com`)
       expect(document['map'][0]['match']).toEqual('/')
       expect(document['map'][0]['name']).toEqual('default')
-      expect(document['map'][0]['acl_profile']).toEqual('__default__')
+      expect(document['map'][0]['acl_profile']).toEqual('__acldefault__')
       expect(document['map'][0]['content_filter_profile']).toEqual('__default__')
       expect(document['map'][0]['acl_active']).toEqual(false)
       expect(document['map'][0]['content_filter_active']).toEqual(false)
@@ -102,7 +102,7 @@ describe('RequestsUtils.ts', () => {
       expect(document['thresholds'][0]['limit']).toEqual(5)
       expect(document['timeframe']).toEqual(60)
       expect(document['key']).toEqual([{'attrs': 'securitypolicyid'},
-        {'attrs': 'securitypolicyentryid'}, {'headers': 'rbzsessionid'}])
+        {'attrs': 'securitypolicyentryid'}, {'attrs': 'curiesession'}])
       expect(document['thresholds'][0]['action']).toEqual('monitor')
       expect(document['pairwith']).toEqual({'self': 'self'})
       expect(document['exclude']).toEqual([])

--- a/src/assets/__tests__/RequestsUtils.spec.ts
+++ b/src/assets/__tests__/RequestsUtils.spec.ts
@@ -225,7 +225,7 @@ describe('RequestsUtils.ts', () => {
   }
 
   const sendRequestBaseUrl = `${RequestsUtils.confAPIRoot}/${RequestsUtils.confAPIVersion}/`
-  const sendRequestUrlTrail = 'configs/master/'
+  const sendRequestUrlTrail = 'configs/prod/'
   const sendReblazeRequestBaseUrl = `${RequestsUtils.reblazeAPIRoot}/${RequestsUtils.reblazeAPIVersion}/reblaze/`
   const sendReblazeRequestUrlTrail = 'config/planet/'
   buildFuncDescribe(RequestsUtils.sendRequest, sendRequestBaseUrl, sendRequestUrlTrail)

--- a/src/components/__tests__/GitHistory.spec.ts
+++ b/src/components/__tests__/GitHistory.spec.ts
@@ -13,7 +13,7 @@ describe.skip('GitHistory.vue', () => {
       'parents': [
         'fc47a6cd9d7f254dd97875a04b87165cc484e075',
       ],
-      'message': 'Update entry [__default__] of document [aclprofiles]',
+      'message': 'Update entry [__acldefault__] of document [aclprofiles]',
       'email': 'curiefense@reblaze.com',
       'author': 'Curiefense API',
     },
@@ -23,7 +23,7 @@ describe.skip('GitHistory.vue', () => {
       'parents': [
         '5aba4a5b9d6faea1896ee8965c7aa651f76af63c',
       ],
-      'message': 'Update entry [__default__] of document [aclprofiles]',
+      'message': 'Update entry [__acldefault__] of document [aclprofiles]',
       'email': 'curiefense@reblaze.com',
       'author': 'Curiefense API',
     },
@@ -33,7 +33,7 @@ describe.skip('GitHistory.vue', () => {
       'parents': [
         '277c5d7bd0e2eb4b9d2944f7eefdfadf37ba8581',
       ],
-      'message': 'Update entry [__default__] of document [aclprofiles]',
+      'message': 'Update entry [__acldefault__] of document [aclprofiles]',
       'email': 'curiefense@reblaze.com',
       'author': 'Curiefense API',
     },
@@ -43,7 +43,7 @@ describe.skip('GitHistory.vue', () => {
       'parents': [
         '878b47deeddac94625fe7c759786f2df885ec541',
       ],
-      'message': 'Update entry [__default__] of document [aclprofiles]',
+      'message': 'Update entry [__acldefault__] of document [aclprofiles]',
       'email': 'curiefense@reblaze.com',
       'author': 'Curiefense API',
     },
@@ -53,7 +53,7 @@ describe.skip('GitHistory.vue', () => {
       'parents': [
         '93c180513fe7edeaf1c0ca69a67aa2a11374da4f',
       ],
-      'message': 'Update entry [__default__] of document [aclprofiles]',
+      'message': 'Update entry [__acldefault__] of document [aclprofiles]',
       'email': 'curiefense@reblaze.com',
       'author': 'Curiefense API',
     },
@@ -63,7 +63,7 @@ describe.skip('GitHistory.vue', () => {
       'parents': [
         '1662043d2a18d6ad2c9c94d6f826593ff5506354',
       ],
-      'message': 'Update entry [__default__] of document [aclprofiles]',
+      'message': 'Update entry [__acldefault__] of document [aclprofiles]',
       'email': 'curiefense@reblaze.com',
       'author': 'Curiefense API',
     },
@@ -73,12 +73,12 @@ describe.skip('GitHistory.vue', () => {
       'parents': [
         '16379cdf39501574b4a2f5a227b82a4454884b84',
       ],
-      'message': 'Create config [master]\n',
+      'message': 'Create config [prod]\n',
       'email': 'curiefense@reblaze.com',
       'author': 'Curiefense API',
     },
   ]
-  const apiPath = '/conf/api/v3/configs/master/d/aclprofiles/e/__default__/v/'
+  const apiPath = '/conf/api/v3/configs/prod/d/aclprofiles/e/__acldefault__/v/'
   let wrapper: any
   beforeEach(() => {
     wrapper = mount(GitHistory, {

--- a/src/components/__tests__/SecurityPoliciesConnections.spec.ts
+++ b/src/components/__tests__/SecurityPoliciesConnections.spec.ts
@@ -39,7 +39,7 @@ describe('SecurityPoliciesConnections.vue', () => {
           {
             'name': 'default',
             'match': '/',
-            'acl_profile': '__default__',
+            'acl_profile': '__acldefault__',
             'acl_active': false,
             'content_filter_profile': '__default__',
             'content_filter_active': false,
@@ -64,7 +64,7 @@ describe('SecurityPoliciesConnections.vue', () => {
           {
             'name': 'default',
             'match': '/',
-            'acl_profile': '__default__',
+            'acl_profile': '__acldefault__',
             'acl_active': false,
             'content_filter_profile': '__default__',
             'content_filter_active': false,
@@ -82,7 +82,7 @@ describe('SecurityPoliciesConnections.vue', () => {
         ],
       },
     ]
-    const selectedBranch = 'master'
+    const selectedBranch = 'prod'
     jest.spyOn(axios, 'get').mockImplementation((path) => {
       if (path === `/conf/api/v3/configs/${selectedBranch}/d/securitypolicies/`) {
         return Promise.resolve({data: securityPoliciesDocs})
@@ -151,7 +151,7 @@ describe('SecurityPoliciesConnections.vue', () => {
             {
               'name': 'default',
               'match': '/',
-              'acl_profile': '__default__',
+              'acl_profile': '__acldefault__',
               'acl_active': false,
               'content_filter_profile': '__default__',
               'content_filter_active': false,
@@ -178,7 +178,7 @@ describe('SecurityPoliciesConnections.vue', () => {
               'match': '/',
               'acl_profile': '__default__',
               'acl_active': false,
-              'content_filter_profile': '__default__',
+              'content_filter_profile': '__acldefault__',
               'content_filter_active': false,
               'limit_ids': ['f971e92459e2', '365757ec0689'],
             },
@@ -194,7 +194,7 @@ describe('SecurityPoliciesConnections.vue', () => {
           ],
         },
       ]
-      const selectedBranch = 'master'
+      const selectedBranch = 'prod'
       jest.spyOn(axios, 'get').mockImplementation((path) => {
         if (path === `/conf/api/v3/configs/${selectedBranch}/d/securitypolicies/`) {
           return Promise.resolve({data: securityPoliciesDocs})
@@ -205,7 +205,7 @@ describe('SecurityPoliciesConnections.vue', () => {
         props: {
           selectedDocId: 'f971e92459e2',
           selectedDocType: 'ratelimits',
-          selectedBranch: 'master',
+          selectedBranch: 'prod',
         },
       })
       const newConnectionButton = wrapper.find('.new-connection-button')

--- a/src/components/__tests__/SideMenu.spec.ts
+++ b/src/components/__tests__/SideMenu.spec.ts
@@ -22,8 +22,8 @@ describe.skip('SideMenu.vue', () => {
   beforeEach(() => {
     gitData = [
       {
-        'id': 'master',
-        'description': 'Update entry [__default__] of document [aclprofiles]',
+        'id': 'prod',
+        'description': 'Update entry [__acldefault__] of document [aclprofiles]',
         'date': '2020-11-10T15:49:17+02:00',
         'logs': [
           {

--- a/src/doc-editors/RoutingProfileEditor.vue
+++ b/src/doc-editors/RoutingProfileEditor.vue
@@ -149,6 +149,10 @@
                             <div class="field">
                               <label class="label is-small">
                                 Path
+                                <span class="has-text-grey is-pulled-right map-entry-id"
+                                      title="Map entry id">
+                                  {{ mapEntry.id }}
+                                </span>
                               </label>
                               <div class="control has-icons-left">
                                 <input class="input is-small current-entry-path"
@@ -527,7 +531,9 @@ export default defineComponent({
 
     addNewProfile(mapEntry: RoutingProfileEntryLocation, idx: number) {
       const newMapEntry = _.cloneDeep(mapEntry)
-      newMapEntry.path = `/new/path/to/match/profile/${DatasetsUtils.generateUUID2()}`
+      const newMapEntryId = DatasetsUtils.generateUUID2()
+      newMapEntry.id = newMapEntryId
+      newMapEntry.path = `/new/path/to/match/profile/${newMapEntryId}`
 
       // reverting the entry match to a stable and valid state if invalid
       if (!this.isSelectedMapEntryPathValid(idx)) {

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -8,8 +8,8 @@
               Name
               <span class="has-text-grey is-pulled-right document-id"
                     title="Document id">
-                    {{ localDoc.id }}
-                  </span>
+                {{ localDoc.id }}
+              </span>
             </label>
             <div class="control">
               <input class="input is-small document-name"
@@ -113,8 +113,8 @@
                             Name
                             <span class="has-text-grey is-pulled-right map-entry-id"
                                   title="Map entry id">
-                                  {{ mapEntry.id }}
-                                </span>
+                              {{ mapEntry.id }}
+                            </span>
                           </label>
                           <div class="control">
                             <input class="input is-small current-entry-name"

--- a/src/doc-editors/WebProxyEditor.vue
+++ b/src/doc-editors/WebProxyEditor.vue
@@ -253,6 +253,9 @@
                             data-qa="mobile-sdk-dropdown"
                             class="document-mobile-sdk-selection"
                             title="Mobile SDK">
+                      <option value="">
+                        None
+                      </option>
                       <option v-for="mobileSDK in mobileSDKsNames"
                               :value="mobileSDK[0]"
                               :key="mobileSDK[0]">

--- a/src/doc-editors/__tests__/ACLEditor.spec.ts
+++ b/src/doc-editors/__tests__/ACLEditor.spec.ts
@@ -16,7 +16,7 @@ describe('ACLEditor.vue', () => {
   beforeEach(() => {
     docs = [
       {
-        'id': '__default__',
+        'id': '__acldefault__',
         'name': 'default-acl',
         'description': 'New ACL Profile Description and Remarks',
         'action': 'monitor',
@@ -51,7 +51,7 @@ describe('ACLEditor.vue', () => {
         'name': 'default monitoring action',
       },
     ]
-    const selectedBranch = 'master'
+    const selectedBranch = 'prod'
     jest.spyOn(axios, 'get').mockImplementation((path) => {
       if (path === `/conf/api/v3/configs/${selectedBranch}/d/actions/`) {
         return Promise.resolve({data: customResponsesDocs})

--- a/src/doc-editors/__tests__/CloudFunctionsEditor.spec.ts
+++ b/src/doc-editors/__tests__/CloudFunctionsEditor.spec.ts
@@ -40,7 +40,7 @@ describe('CloudFunctionsEditor.vue', () => {
           {
             'name': 'default',
             'match': '/',
-            'acl_profile': '__default__',
+            'acl_profile': '__acldefault__',
             'acl_active': false,
             'content_filter_profile': '__default__',
             'content_filter_active': false,
@@ -65,7 +65,7 @@ describe('CloudFunctionsEditor.vue', () => {
           {
             'name': 'default',
             'match': '/',
-            'acl_profile': '__default__',
+            'acl_profile': '__acldefault__',
             'acl_active': false,
             'content_filter_profile': '__default__',
             'content_filter_active': false,
@@ -83,7 +83,7 @@ describe('CloudFunctionsEditor.vue', () => {
         ],
       },
     ]
-    const selectedBranch = 'master'
+    const selectedBranch = 'prod'
     jest.spyOn(axios, 'get').mockImplementation((path) => {
       if (path === `/conf/api/v3/configs/${selectedBranch}/d/securitypolicies/`) {
         return Promise.resolve({data: securityPoliciesDocs})

--- a/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
+++ b/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
@@ -136,7 +136,7 @@ describe('ContentFilterProfileEditor.vue', () => {
     wrapper = shallowMount(ContentFilterEditor, {
       props: {
         'selectedDoc': docs[0],
-        'selectedBranch': 'master',
+        'selectedBranch': 'prod',
         'onUpdate:selectedDoc': onUpdate,
       },
     })
@@ -412,7 +412,7 @@ describe('ContentFilterProfileEditor.vue', () => {
         wrapper = shallowMount(ContentFilterEditor, {
           props: {
             selectedDoc: docsForNormalization[0],
-            selectedBranch: 'master',
+            selectedBranch: 'prod',
           },
         })
       })
@@ -483,7 +483,7 @@ describe('ContentFilterProfileEditor.vue', () => {
         wrapper = shallowMount(ContentFilterEditor, {
           props: {
             selectedDoc: docsShouldNotNormalize[0],
-            selectedBranch: 'master',
+            selectedBranch: 'prod',
           },
         })
         expect(wrapper.emitted('update:selectedDoc')).toBeFalsy()
@@ -539,7 +539,7 @@ describe('ContentFilterProfileEditor.vue', () => {
         wrapper = shallowMount(ContentFilterEditor, {
           props: {
             selectedDoc: docsForNormalization[0],
-            selectedBranch: 'master',
+            selectedBranch: 'prod',
           },
         })
       })

--- a/src/doc-editors/__tests__/DynamicRulesEditor.spec.ts
+++ b/src/doc-editors/__tests__/DynamicRulesEditor.spec.ts
@@ -58,7 +58,7 @@ describe('DynamicRulesEditor.vue', () => {
         'name': 'default monitoring action',
       },
     ]
-    selectedBranch = 'master',
+    selectedBranch = 'prod',
 
     mockRouter = {
       push: jest.fn(),
@@ -159,7 +159,7 @@ describe('DynamicRulesEditor.vue', () => {
         },
       }
       jest.spyOn(axios, 'get').mockImplementation((path) => {
-        if (path === `db/master/k/autocomplete/`) {
+        if (path === `db/prod/k/autocomplete/`) {
           return Promise.resolve(tagsData)
         }
         return Promise.resolve()

--- a/src/doc-editors/__tests__/FlowControlPolicyEditor.spec.ts
+++ b/src/doc-editors/__tests__/FlowControlPolicyEditor.spec.ts
@@ -194,7 +194,7 @@ describe('FlowControlPolicyEditor.vue', () => {
         },
       }
       jest.spyOn(axios, 'get').mockImplementation((path) => {
-        if (path === `db/master/k/autocomplete/`) {
+        if (path === `db/prod/k/autocomplete/`) {
           return Promise.resolve(tagsData)
         }
         return Promise.resolve()

--- a/src/doc-editors/__tests__/GlobalFilterListEditor.spec.ts
+++ b/src/doc-editors/__tests__/GlobalFilterListEditor.spec.ts
@@ -77,7 +77,7 @@ describe('GlobalFilterListEditor.vue', () => {
         'name': 'default monitoring action',
       },
     ]
-    const selectedBranch = 'master'
+    const selectedBranch = 'prod'
     jest.spyOn(axios, 'get').mockImplementation((path) => {
       if (path === `/conf/api/v3/configs/${selectedBranch}/d/actions/`) {
         return Promise.resolve({data: customResponsesDocs})

--- a/src/doc-editors/__tests__/RateLimitsEditor.spec.ts
+++ b/src/doc-editors/__tests__/RateLimitsEditor.spec.ts
@@ -30,7 +30,7 @@ describe('RateLimitsEditor.vue', () => {
       'timeframe': '60',
       'include': ['blocklist'],
       'exclude': ['allowlist'],
-      'key': [{'attrs': 'securitypolicyid'}, {'attrs': 'securitypolicyentryid'}, {'headers': 'rbzsessionid'}],
+      'key': [{'attrs': 'securitypolicyid'}, {'attrs': 'securitypolicyentryid'}, {'attrs': 'curiesession'}],
       'pairwith': {'self': 'self'},
     }]
     securityPoliciesDocs = [
@@ -42,7 +42,7 @@ describe('RateLimitsEditor.vue', () => {
           {
             'name': 'default',
             'match': '/',
-            'acl_profile': '__default__',
+            'acl_profile': '__acldefault__',
             'acl_active': false,
             'content_filter_profile': '__default__',
             'content_filter_active': false,
@@ -67,7 +67,7 @@ describe('RateLimitsEditor.vue', () => {
           {
             'name': 'default',
             'match': '/',
-            'acl_profile': '__default__',
+            'acl_profile': '__acldefault__',
             'acl_active': false,
             'content_filter_profile': '__default__',
             'content_filter_active': false,
@@ -95,7 +95,7 @@ describe('RateLimitsEditor.vue', () => {
         'name': 'default monitoring action',
       },
     ]
-    const selectedBranch = 'master'
+    const selectedBranch = 'prod'
     jest.spyOn(axios, 'get').mockImplementation((path) => {
       if (path === `/conf/api/v3/configs/${selectedBranch}/d/securitypolicies/`) {
         return Promise.resolve({data: securityPoliciesDocs})
@@ -392,7 +392,7 @@ describe('RateLimitsEditor.vue', () => {
         },
       }
       jest.spyOn(axios, 'get').mockImplementation((path) => {
-        if (path === `db/master/k/autocomplete/`) {
+        if (path === `db/prod/k/autocomplete/`) {
           return Promise.resolve(tagsData)
         }
         return Promise.resolve()
@@ -499,7 +499,7 @@ describe('RateLimitsEditor.vue', () => {
             {
               'name': 'default',
               'match': '/',
-              'acl_profile': '__default__',
+              'acl_profile': '__acldefault__',
               'acl_active': false,
               'content_filter_profile': '__default__',
               'content_filter_active': false,
@@ -524,7 +524,7 @@ describe('RateLimitsEditor.vue', () => {
             {
               'name': 'default',
               'match': '/',
-              'acl_profile': '__default__',
+              'acl_profile': '__acldefault__',
               'acl_active': false,
               'content_filter_profile': '__default__',
               'content_filter_active': false,
@@ -545,7 +545,7 @@ describe('RateLimitsEditor.vue', () => {
       wrapper = mount(RateLimitsEditor, {
         props: {
           selectedDoc: rateLimitsDocs[0],
-          selectedBranch: 'master',
+          selectedBranch: 'prod',
         },
       })
       const newConnectionButton = wrapper.find('.new-connection-button')

--- a/src/doc-editors/__tests__/SecurityPoliciesEditor.spec.ts
+++ b/src/doc-editors/__tests__/SecurityPoliciesEditor.spec.ts
@@ -32,7 +32,7 @@ describe.skip('SecurityPoliciesEditor.vue', () => {
             'id': '__default__',
             'name': 'default',
             'match': '/',
-            'acl_profile': '__default__',
+            'acl_profile': '__acldefault__',
             'acl_active': false,
             'content_filter_profile': '__default__',
             'content_filter_active': false,
@@ -59,7 +59,7 @@ describe.skip('SecurityPoliciesEditor.vue', () => {
             'id': '__default2__',
             'name': 'default',
             'match': '/',
-            'acl_profile': '__default__',
+            'acl_profile': '__acldefault__',
             'acl_active': false,
             'content_filter_profile': '__default__',
             'content_filter_active': false,
@@ -80,7 +80,7 @@ describe.skip('SecurityPoliciesEditor.vue', () => {
     ]
     aclDocs = [
       {
-        'id': '__default__',
+        'id': '__acldefault__',
         'name': 'default acl',
         'allow': [],
         'allow_bot': [
@@ -233,7 +233,7 @@ describe.skip('SecurityPoliciesEditor.vue', () => {
         'pairwith': {'self': 'self'},
       },
     ]
-    selectedBranch = 'master'
+    selectedBranch = 'prod'
     axiosGetSpy = jest.spyOn(axios, 'get').mockImplementation((path, config) => {
       if (!wrapper) {
         return Promise.resolve({data: []})
@@ -325,7 +325,7 @@ describe.skip('SecurityPoliciesEditor.vue', () => {
         {
           'name': 'default',
           'match': '/',
-          'acl_profile': '__default__',
+          'acl_profile': '__acldefault__',
           'acl_active': false,
           'content_filter_profile': '__default__',
           'content_filter_active': false,
@@ -371,7 +371,7 @@ describe.skip('SecurityPoliciesEditor.vue', () => {
         {
           'name': 'default',
           'match': '/',
-          'acl_profile': '__default__',
+          'acl_profile': '__acldefault__',
           'acl_active': false,
           'content_filter_profile': '__default__',
           'content_filter_active': false,
@@ -485,7 +485,7 @@ describe.skip('SecurityPoliciesEditor.vue', () => {
         {
           'name': 'two',
           'match': '/two',
-          'acl_profile': '__default__',
+          'acl_profile': '__acldefault__',
           'acl_active': true,
           'content_filter_profile': '__default__',
           'content_filter_active': false,
@@ -1142,7 +1142,7 @@ describe.skip('SecurityPoliciesEditor.vue', () => {
             {
               'name': 'two',
               'match': '/two',
-              'acl_profile': '__default__',
+              'acl_profile': '__acldefault__',
               'acl_active': true,
               'content_filter_profile': '__default__',
               'content_filter_active': false,
@@ -1151,7 +1151,7 @@ describe.skip('SecurityPoliciesEditor.vue', () => {
             {
               'name': 'three',
               'match': '/three',
-              'acl_profile': '__default__',
+              'acl_profile': '__acldefault__',
               'acl_active': true,
               'content_filter_profile': '__default__',
               'content_filter_active': false,
@@ -1160,7 +1160,7 @@ describe.skip('SecurityPoliciesEditor.vue', () => {
             {
               'name': 'four',
               'match': '/four',
-              'acl_profile': '__default__',
+              'acl_profile': '__acldefault__',
               'acl_active': true,
               'content_filter_profile': '__default__',
               'content_filter_active': false,

--- a/src/stores/BranchesStore.ts
+++ b/src/stores/BranchesStore.ts
@@ -54,7 +54,7 @@ export const useBranchesStore = defineStore('branches', () => {
       }).then((response: AxiosResponse) => {
         console.log('Branches loaded: ', response.data)
         setBranches(response.data)
-        const branchNameFromRoute = route.params.branch.toString()
+        const branchNameFromRoute = route.params.branch?.toString()
         setSelectedBranch(branchNameFromRoute)
         _loading.value = false
         resolve(list.value)

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -297,6 +297,7 @@ declare module CuriefenseClient {
   }
 
   type RoutingProfileEntryLocation = {
+    id: string
     path: string
     backend_id: string
     cloud_functions: string[]

--- a/src/views/DocumentEditor.vue
+++ b/src/views/DocumentEditor.vue
@@ -309,10 +309,13 @@ export default defineComponent({
 
     selectedDocNotDeletable(): boolean {
       return !this.selectedDoc ||
-          this.selectedDoc.id === '__default__' ||
+          this.selectedDoc.id.startsWith('__') || // Default entries
+          this.selectedDoc.id.startsWith('rl-') || // Reblaze-managed Rate Limits
+          this.selectedDoc.id.startsWith('action-') || // Reblaze-managed Custom Responses
+          this.selectedDoc.id.startsWith('rbz-') || // Reblaze-managed Global Filters
+          this.selectedDoc.id.startsWith('dr_') || // Dynamic-Rule-managed Global Filters
           this.isDocReferenced ||
-          this.docs.length <= 1 ||
-          this.selectedDoc.id.startsWith('dr_')
+          this.docs.length <= 1
     },
 
     selectedDocIndex(): number {
@@ -383,7 +386,6 @@ export default defineComponent({
       this.isDocumentInvalid = false
 
       await this.loadSelectedDocData()
-      this.addMissingDefaultsToDoc()
       await this.goToRoute()
       this.setLoadingDocStatus(false)
     },
@@ -482,7 +484,6 @@ export default defineComponent({
           this.selectedDocID = this.docIdNames[0][0]
         }
         await this.loadSelectedDocData()
-        this.addMissingDefaultsToDoc()
       }
       this.setLoadingDocStatus(false)
       this.isDownloadLoading = false
@@ -642,7 +643,6 @@ export default defineComponent({
 
       this.selectedDocID = this.docs[0].id
       await this.loadSelectedDocData()
-      this.addMissingDefaultsToDoc()
       this.goToRoute()
       this.isDeleteLoading = false
       this.setLoadingDocStatus(false)
@@ -673,13 +673,6 @@ export default defineComponent({
 
     restoreGitVersion() {
       this.loadDocs(true)
-    },
-
-    addMissingDefaultsToDoc() {
-      if (!this.selectedDoc) {
-        return
-      }
-      this.selectedDoc = {...this.newDoc(), ...this.selectedDoc as {}}
     },
 
     // Collect every request to display a loading indicator

--- a/src/views/__tests__/DocumentEditor.spec.ts
+++ b/src/views/__tests__/DocumentEditor.spec.ts
@@ -45,8 +45,8 @@ describe.skip('DocumentEditor.vue', () => {
   beforeEach((done) => {
     gitData = [
       {
-        'id': 'master',
-        'description': 'Update entry [__default__] of document [aclprofiles]',
+        'id': 'prod',
+        'description': 'Update entry [__acldefault__] of document [aclprofiles]',
         'date': '2020-11-10T15:49:17+02:00',
         'logs': [
           {
@@ -55,7 +55,7 @@ describe.skip('DocumentEditor.vue', () => {
             'parents': [
               'fc47a6cd9d7f254dd97875a04b87165cc484e075',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -65,7 +65,7 @@ describe.skip('DocumentEditor.vue', () => {
             'parents': [
               '5aba4a5b9d6faea1896ee8965c7aa651f76af63c',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -75,7 +75,7 @@ describe.skip('DocumentEditor.vue', () => {
             'parents': [
               '277c5d7bd0e2eb4b9d2944f7eefdfadf37ba8581',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -85,7 +85,7 @@ describe.skip('DocumentEditor.vue', () => {
             'parents': [
               '878b47deeddac94625fe7c759786f2df885ec541',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -95,7 +95,7 @@ describe.skip('DocumentEditor.vue', () => {
             'parents': [
               '93c180513fe7edeaf1c0ca69a67aa2a11374da4f',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -105,7 +105,7 @@ describe.skip('DocumentEditor.vue', () => {
             'parents': [
               '1662043d2a18d6ad2c9c94d6f826593ff5506354',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -115,7 +115,7 @@ describe.skip('DocumentEditor.vue', () => {
             'parents': [
               '16379cdf39501574b4a2f5a227b82a4454884b84',
             ],
-            'message': 'Create config [master]\n',
+            'message': 'Create config [prod]\n',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -159,7 +159,7 @@ describe.skip('DocumentEditor.vue', () => {
     ]
     aclDocs = [
       {
-        'id': '__default__',
+        'id': '__acldefault__',
         'name': 'default-acl',
         'action': 'monitor',
         'allow': [],
@@ -216,7 +216,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '7a24bd37e93e812fa5173c4b2fb0068ad8e4ffdd',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -226,7 +226,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '886baf66ddd032744ac34b848c8412386a160fb3',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -236,7 +236,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             'af98cb28fc4db3a76c3a51d697b6037e8695dd7b',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -246,7 +246,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             'cda70058b632405600db1fbc5cf8dfd90514ec30',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -416,7 +416,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             'fc47a6cd9d7f254dd97875a04b87165cc484e075',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -426,7 +426,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '5aba4a5b9d6faea1896ee8965c7aa651f76af63c',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -436,7 +436,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '277c5d7bd0e2eb4b9d2944f7eefdfadf37ba8581',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -446,7 +446,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '878b47deeddac94625fe7c759786f2df885ec541',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -456,7 +456,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '93c180513fe7edeaf1c0ca69a67aa2a11374da4f',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -466,7 +466,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '1662043d2a18d6ad2c9c94d6f826593ff5506354',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -476,7 +476,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '16379cdf39501574b4a2f5a227b82a4454884b84',
           ],
-          'message': 'Create config [master]\n',
+          'message': 'Create config [prod]\n',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -488,7 +488,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '1662043d2a18d6ad2c9c94d6f826593ff5506354',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -498,7 +498,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '16379cdf39501574b4a2f5a227b82a4454884b84',
           ],
-          'message': 'Create config [master]\n',
+          'message': 'Create config [prod]\n',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -506,7 +506,7 @@ describe.skip('DocumentEditor.vue', () => {
     ]
     aclGitOldVersion = [
       {
-        'id': '__default__',
+        'id': '__acldefault__',
         'name': 'default-acl',
         'allow': [],
         'allow_bot': [
@@ -586,7 +586,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '16379cdf39501574b4a2f5a227b82a4454884b84',
           ],
-          'message': 'Create config [master]\n',
+          'message': 'Create config [prod]\n',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -618,7 +618,7 @@ describe.skip('DocumentEditor.vue', () => {
           'parents': [
             '16379cdf39501574b4a2f5a227b82a4454884b84',
           ],
-          'message': 'Create config [master]\n',
+          'message': 'Create config [prod]\n',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -780,7 +780,7 @@ describe.skip('DocumentEditor.vue', () => {
         }
         return Promise.resolve({data: aclDocs})
       }
-      if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/__default__/`) {
+      if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/__acldefault__/`) {
         return Promise.resolve({data: aclDocs[0]})
       }
       if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/5828321c37e0/`) {
@@ -789,10 +789,10 @@ describe.skip('DocumentEditor.vue', () => {
       if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/v/7f8a987c8e5e9db7c734ac8841c543d5bc5d9657/`) {
         return Promise.resolve({data: aclGitOldVersion})
       }
-      if (path === `/conf/api/v3/configs/master/d/aclprofiles/e/__default__/v/`) {
+      if (path === `/conf/api/v3/configs/prod/d/aclprofiles/e/__acldefault__/v/`) {
         return Promise.resolve({data: aclDocsLogs[0]})
       }
-      if (path === `/conf/api/v3/configs/zzz_branch/d/aclprofiles/e/__default__/v/`) {
+      if (path === `/conf/api/v3/configs/zzz_branch/d/aclprofiles/e/__acldefault__/v/`) {
         return Promise.resolve({data: aclDocsLogs[1]})
       }
       if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/5828321c37e0/v/`) {
@@ -859,7 +859,7 @@ describe.skip('DocumentEditor.vue', () => {
         }
         return Promise.resolve({data: cloudFunctionsDocs[0]})
       }
-      if (path === '/conf/api/v3/configs/master/v/') {
+      if (path === '/conf/api/v3/configs/prod/v/') {
         return Promise.resolve({data: gitData[0].logs})
       }
       if (path === '/conf/api/v3/configs/zzz_branch/v/') {
@@ -869,11 +869,11 @@ describe.skip('DocumentEditor.vue', () => {
     })
     mockRoute = {
       params: {
-        branch: 'master',
+        branch: 'prod',
         doc_type: 'aclprofiles',
-        doc_id: '__default__',
+        doc_id: '__acldefault__',
       },
-      path: `/config/master/aclprofiles/__default__`,
+      path: `/config/prod/aclprofiles/__acldefault__`,
       name: `DocumentEditor`,
     }
     mockRouter = {
@@ -924,7 +924,7 @@ describe.skip('DocumentEditor.vue', () => {
       if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/${docID}/`) {
         return Promise.resolve({data: aclDocs[0]})
       }
-      if (path === `/conf/api/v3/configs/master/d/aclprofiles/e/${docID}/v/`) {
+      if (path === `/conf/api/v3/configs/prod/d/aclprofiles/e/${docID}/v/`) {
         return Promise.resolve(null)
       }
       return Promise.resolve({data: []})
@@ -954,7 +954,7 @@ describe.skip('DocumentEditor.vue', () => {
       if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/${docID}/`) {
         return Promise.resolve({data: aclDocs[0]})
       }
-      if (path === `/conf/api/v3/configs/master/d/aclprofiles/e/${docID}/v/`) {
+      if (path === `/conf/api/v3/configs/prod/d/aclprofiles/e/${docID}/v/`) {
         return Promise.resolve({data: null})
       }
       return Promise.resolve({data: []})
@@ -984,7 +984,7 @@ describe.skip('DocumentEditor.vue', () => {
       if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/${docID}/`) {
         return Promise.resolve({data: aclDocs[0]})
       }
-      if (path === `/conf/api/v3/configs/master/d/aclprofiles/e/${docID}/v/`) {
+      if (path === `/conf/api/v3/configs/prod/d/aclprofiles/e/${docID}/v/`) {
         return Promise.resolve(null)
       }
       return Promise.resolve({data: []})
@@ -1014,7 +1014,7 @@ describe.skip('DocumentEditor.vue', () => {
       if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/${docID}/`) {
         return Promise.resolve({data: aclDocs[0]})
       }
-      if (path === `/conf/api/v3/configs/master/d/aclprofiles/e/${docID}/v/`) {
+      if (path === `/conf/api/v3/configs/prod/d/aclprofiles/e/${docID}/v/`) {
         return Promise.resolve({data: null})
       }
       return Promise.resolve({data: []})
@@ -1040,7 +1040,7 @@ describe.skip('DocumentEditor.vue', () => {
     const gitHistory = wrapper.findComponent(GitHistory)
     gitHistory.vm.$emit('restore-version', wantedVersion)
     await nextTick()
-    expect(putSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/aclprofiles/v/${wantedVersion.version}/revert/`)
+    expect(putSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/aclprofiles/v/${wantedVersion.version}/revert/`)
   })
 
   test('should log message when receiving no configs from the server', (done) => {
@@ -1175,7 +1175,7 @@ describe.skip('DocumentEditor.vue', () => {
       mockRoute.params = {
         branch: 'zzz_branch',
         doc_type: 'aclprofiles',
-        doc_id: '__default__',
+        doc_id: '__acldefault__',
       }
       wrapper = shallowMount(DocumentEditor, {
         global: {
@@ -1199,7 +1199,7 @@ describe.skip('DocumentEditor.vue', () => {
 
     test('should load correct document type from route without changing branch or document id', (done) => {
       mockRoute.params = {
-        branch: 'master',
+        branch: 'prod',
         doc_type: 'securitypolicies',
         doc_id: '__default__',
       }
@@ -1225,7 +1225,7 @@ describe.skip('DocumentEditor.vue', () => {
 
     test('should load correct document id from route without changing branch or document type', (done) => {
       mockRoute.params = {
-        branch: 'master',
+        branch: 'prod',
         doc_type: 'aclprofiles',
         doc_id: '5828321c37e0',
       }
@@ -1356,8 +1356,8 @@ describe.skip('DocumentEditor.vue', () => {
     test('should display correct singular amount of branches', (done) => {
       gitData = [
         {
-          'id': 'master',
-          'description': 'Update entry [__default__] of document [aclprofiles]',
+          'id': 'prod',
+          'description': 'Update entry [__acldefault__] of document [aclprofiles]',
           'date': '2020-11-10T15:49:17+02:00',
           'logs': [{
             'version': '7dd9580c00bef1049ee9a531afb13db9ef3ee956',
@@ -1365,7 +1365,7 @@ describe.skip('DocumentEditor.vue', () => {
             'parents': [
               'fc47a6cd9d7f254dd97875a04b87165cc484e075',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           }],
@@ -1376,10 +1376,10 @@ describe.skip('DocumentEditor.vue', () => {
         if (path === '/conf/api/v3/configs/') {
           return Promise.resolve({data: gitData})
         }
-        if (path === '/conf/api/v3/configs/master/') {
+        if (path === '/conf/api/v3/configs/prod/') {
           return Promise.resolve({data: gitData[0]})
         }
-        if (path === '/conf/api/v3/configs/master/v/') {
+        if (path === '/conf/api/v3/configs/prod/v/') {
           return Promise.resolve({data: gitData[0].logs})
         }
         return Promise.resolve({data: []})
@@ -1403,8 +1403,8 @@ describe.skip('DocumentEditor.vue', () => {
     test('should display correct singular amount of commits', (done) => {
       gitData = [
         {
-          'id': 'master',
-          'description': 'Update entry [__default__] of document [aclprofiles]',
+          'id': 'prod',
+          'description': 'Update entry [__acldefault__] of document [aclprofiles]',
           'date': '2020-11-10T15:49:17+02:00',
           'logs': [{
             'version': '7dd9580c00bef1049ee9a531afb13db9ef3ee956',
@@ -1412,7 +1412,7 @@ describe.skip('DocumentEditor.vue', () => {
             'parents': [
               'fc47a6cd9d7f254dd97875a04b87165cc484e075',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           }],
@@ -1423,10 +1423,10 @@ describe.skip('DocumentEditor.vue', () => {
         if (path === '/conf/api/v3/configs/') {
           return Promise.resolve({data: gitData})
         }
-        if (path === '/conf/api/v3/configs/master/') {
+        if (path === '/conf/api/v3/configs/prod/') {
           return Promise.resolve({data: gitData[0]})
         }
-        if (path === '/conf/api/v3/configs/master/v/') {
+        if (path === '/conf/api/v3/configs/prod/v/') {
           return Promise.resolve({data: gitData[0].logs})
         }
         return Promise.resolve({data: []})
@@ -1540,7 +1540,7 @@ describe.skip('DocumentEditor.vue', () => {
         const getSpy = jest.spyOn(axios, 'get')
         const saveDocumentButton = wrapper.find('.save-document-button')
         saveDocumentButton.trigger('click')
-        expect(getSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/securitypolicies/`)
+        expect(getSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/securitypolicies/`)
         done()
       })
     })
@@ -1552,7 +1552,7 @@ describe.skip('DocumentEditor.vue', () => {
       putSpy.mockImplementation(() => Promise.resolve())
       const saveDocumentButton = wrapper.find('.save-document-button')
       saveDocumentButton.trigger('click')
-      expect(putSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/aclprofiles/e/${doc.id}/`, doc)
+      expect(putSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/aclprofiles/e/${doc.id}/`, doc)
     })
 
     test('should be able to fork document', () => {
@@ -1564,7 +1564,7 @@ describe.skip('DocumentEditor.vue', () => {
       postSpy.mockImplementation(() => Promise.resolve())
       const forkDocumentButton = wrapper.find('.fork-document-button')
       forkDocumentButton.trigger('click')
-      expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/aclprofiles/e/`, forkedDoc)
+      expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/aclprofiles/e/`, forkedDoc)
     })
 
     test('should not be able to fork document if there is no selected doc', () => {
@@ -1610,7 +1610,7 @@ describe.skip('DocumentEditor.vue', () => {
         postSpy.mockImplementation(() => Promise.resolve())
         const forkDocumentButton = wrapper.find('.fork-document-button')
         forkDocumentButton.trigger('click')
-        expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/securitypolicies/e/`, forkedDoc)
+        expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/securitypolicies/e/`, forkedDoc)
         done()
       })
     })
@@ -1622,7 +1622,7 @@ describe.skip('DocumentEditor.vue', () => {
       postSpy.mockImplementation(() => Promise.resolve())
       const newDocumentButton = wrapper.find('.new-document-button')
       newDocumentButton.trigger('click')
-      expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/aclprofiles/e/`, newDoc)
+      expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/aclprofiles/e/`, newDoc)
     })
 
     test('should be able to add multiple new documents in a row with different IDs', () => {
@@ -1648,13 +1648,22 @@ describe.skip('DocumentEditor.vue', () => {
       const docID = wrapper.vm.selectedDocID
       const deleteDocumentButton = wrapper.find('.delete-document-button')
       await deleteDocumentButton.trigger('click')
-      expect(deleteSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/aclprofiles/e/${docID}/`)
+      expect(deleteSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/aclprofiles/e/${docID}/`)
     })
 
-    test('should not be able to delete a document if its id is __default__', () => {
+    test('should not be able to delete a document if its id starts with `__` #1', () => {
       const deleteSpy = jest.spyOn(axios, 'delete')
       deleteSpy.mockImplementation(() => Promise.resolve())
       wrapper.setData({selectedDocID: '__default__'})
+      const deleteDocumentButton = wrapper.find('.delete-document-button')
+      deleteDocumentButton.trigger('click')
+      expect(deleteSpy).not.toHaveBeenCalled()
+    })
+
+    test('should not be able to delete a document if its id starts with `__` #2', () => {
+      const deleteSpy = jest.spyOn(axios, 'delete')
+      deleteSpy.mockImplementation(() => Promise.resolve())
+      wrapper.setData({selectedDocID: '__acldefault__'})
       const deleteDocumentButton = wrapper.find('.delete-document-button')
       deleteDocumentButton.trigger('click')
       expect(deleteSpy).not.toHaveBeenCalled()
@@ -1668,7 +1677,7 @@ describe.skip('DocumentEditor.vue', () => {
       docSelection.setValue(options.at(1).element.value)
       const deleteSpy = jest.spyOn(axios, 'delete')
       deleteSpy.mockImplementation(() => Promise.resolve())
-      wrapper.setData({selectedDoc: {id: '__default__'}})
+      wrapper.setData({selectedDoc: {id: '__acldefault__'}})
       const deleteDocumentButton = wrapper.find('.delete-document-button')
       deleteDocumentButton.trigger('click')
       expect(deleteSpy).not.toHaveBeenCalled()
@@ -1719,7 +1728,7 @@ describe.skip('DocumentEditor.vue', () => {
             return Promise.resolve({data: aclDocs})
           }, 5000)
         }
-        if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/__default__/`) {
+        if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/__acldefault__/`) {
           return Promise.resolve({data: aclDocs[0]})
         }
         if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/5828321c37e0/`) {
@@ -1929,13 +1938,13 @@ describe.skip('DocumentEditor.vue', () => {
           if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/${docID}/`) {
             return Promise.resolve({data: aclDocs[0]})
           }
-          if (path === `/conf/api/v3/configs/master/d/aclprofiles/e/${docID}/v/`) {
+          if (path === `/conf/api/v3/configs/prod/d/aclprofiles/e/${docID}/v/`) {
             return Promise.resolve({data: aclDocsLogs[0]})
           }
           if (path === `/conf/api/v3/configs/${branch}/d/securitypolicies/`) {
             return Promise.resolve(null)
           }
-          if (path === '/conf/api/v3/configs/master/v/') {
+          if (path === '/conf/api/v3/configs/prod/v/') {
             return Promise.resolve({data: gitData[0].logs})
           }
           if (path === '/conf/api/v3/configs/zzz_branch/v/') {
@@ -1975,13 +1984,13 @@ describe.skip('DocumentEditor.vue', () => {
           if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/e/${docID}/`) {
             return Promise.resolve({data: aclDocs[0]})
           }
-          if (path === `/conf/api/v3/configs/master/d/aclprofiles/e/${docID}/v/`) {
+          if (path === `/conf/api/v3/configs/prod/d/aclprofiles/e/${docID}/v/`) {
             return Promise.resolve({data: aclDocsLogs[0]})
           }
           if (path === `/conf/api/v3/configs/${branch}/d/securitypolicies/`) {
             return Promise.resolve({data: null})
           }
-          if (path === '/conf/api/v3/configs/master/v/') {
+          if (path === '/conf/api/v3/configs/prod/v/') {
             return Promise.resolve({data: gitData[0].logs})
           }
           if (path === '/conf/api/v3/configs/zzz_branch/v/') {

--- a/src/views/__tests__/DocumentList.spec.ts
+++ b/src/views/__tests__/DocumentList.spec.ts
@@ -46,8 +46,8 @@ describe.skip('DocumentList.vue', () => {
   beforeEach((done) => {
     gitData = [
       {
-        'id': 'master',
-        'description': 'Update entry [__default__] of document [aclprofiles]',
+        'id': 'prod',
+        'description': 'Update entry [__acldefault__] of document [aclprofiles]',
         'date': '2020-11-10T15:49:17+02:00',
         'logs': [
           {
@@ -56,7 +56,7 @@ describe.skip('DocumentList.vue', () => {
             'parents': [
               'fc47a6cd9d7f254dd97875a04b87165cc484e075',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -66,7 +66,7 @@ describe.skip('DocumentList.vue', () => {
             'parents': [
               '5aba4a5b9d6faea1896ee8965c7aa651f76af63c',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -76,7 +76,7 @@ describe.skip('DocumentList.vue', () => {
             'parents': [
               '277c5d7bd0e2eb4b9d2944f7eefdfadf37ba8581',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -86,7 +86,7 @@ describe.skip('DocumentList.vue', () => {
             'parents': [
               '878b47deeddac94625fe7c759786f2df885ec541',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -96,7 +96,7 @@ describe.skip('DocumentList.vue', () => {
             'parents': [
               '93c180513fe7edeaf1c0ca69a67aa2a11374da4f',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -106,7 +106,7 @@ describe.skip('DocumentList.vue', () => {
             'parents': [
               '1662043d2a18d6ad2c9c94d6f826593ff5506354',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -116,7 +116,7 @@ describe.skip('DocumentList.vue', () => {
             'parents': [
               '16379cdf39501574b4a2f5a227b82a4454884b84',
             ],
-            'message': 'Create config [master]\n',
+            'message': 'Create config [prod]\n',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -160,7 +160,7 @@ describe.skip('DocumentList.vue', () => {
     ]
     aclDocs = [
       {
-        'id': '__default__',
+        'id': '__acldefault__',
         'name': 'default-acl',
         'tags': ['google', 'china'],
       },
@@ -188,7 +188,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             '7a24bd37e93e812fa5173c4b2fb0068ad8e4ffdd',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -198,7 +198,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             '886baf66ddd032744ac34b848c8412386a160fb3',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -208,7 +208,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             'af98cb28fc4db3a76c3a51d697b6037e8695dd7b',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -218,7 +218,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             'cda70058b632405600db1fbc5cf8dfd90514ec30',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -388,7 +388,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             'fc47a6cd9d7f254dd97875a04b87165cc484e075',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -398,7 +398,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             '5aba4a5b9d6faea1896ee8965c7aa651f76af63c',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -408,7 +408,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             '277c5d7bd0e2eb4b9d2944f7eefdfadf37ba8581',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -418,7 +418,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             '878b47deeddac94625fe7c759786f2df885ec541',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -428,7 +428,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             '93c180513fe7edeaf1c0ca69a67aa2a11374da4f',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -438,7 +438,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             '1662043d2a18d6ad2c9c94d6f826593ff5506354',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -448,7 +448,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             '16379cdf39501574b4a2f5a227b82a4454884b84',
           ],
-          'message': 'Create config [master]\n',
+          'message': 'Create config [prod]\n',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -460,7 +460,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             '1662043d2a18d6ad2c9c94d6f826593ff5506354',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -470,7 +470,7 @@ describe.skip('DocumentList.vue', () => {
           'parents': [
             '16379cdf39501574b4a2f5a227b82a4454884b84',
           ],
-          'message': 'Create config [master]\n',
+          'message': 'Create config [prod]\n',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         },
@@ -478,7 +478,7 @@ describe.skip('DocumentList.vue', () => {
     ]
     aclGitOldVersion = [
       {
-        'id': '__default__',
+        'id': '__acldefault__',
         'name': 'default-acl',
         'tags': ['google', 'china'],
       },
@@ -736,7 +736,7 @@ describe.skip('DocumentList.vue', () => {
       if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/v/7f8a987c8e5e9db7c734ac8841c543d5bc5d9657/`) {
         return Promise.resolve({data: aclGitOldVersion})
       }
-      if (path === `/conf/api/v3/configs/master/d/globalfilters/`) {
+      if (path === `/conf/api/v3/configs/prod/d/globalfilters/`) {
         const globalFilterXFields = _.flatMap(COLUMN_OPTIONS_MAP['globalfilters'], 'fieldNames')
         globalFilterXFields.unshift('id')
         if (config && config.headers && config.headers['x-fields'] === globalFilterXFields.join(', ')) {
@@ -797,7 +797,7 @@ describe.skip('DocumentList.vue', () => {
         }
         return Promise.resolve({data: rateLimitsDocs})
       }
-      if (path === '/conf/api/v3/configs/master/v/') {
+      if (path === '/conf/api/v3/configs/prod/v/') {
         return Promise.resolve({data: gitData[0].logs})
       }
       if (path === '/conf/api/v3/configs/zzz_branch/v/') {
@@ -807,10 +807,10 @@ describe.skip('DocumentList.vue', () => {
     })
     mockRoute = {
       params: {
-        branch: 'master',
+        branch: 'prod',
         doc_type: 'aclprofiles',
       },
-      path: `/list/master/aclprofiles`,
+      path: `/list/prod/aclprofiles`,
       name: `DocumentList`,
     }
     mockRouter = {
@@ -856,7 +856,7 @@ describe.skip('DocumentList.vue', () => {
         if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/`) {
           return Promise.resolve({data: aclDocs})
         }
-        if (path === `/conf/api/v3/configs/master/d/aclprofiles/v/`) {
+        if (path === `/conf/api/v3/configs/prod/d/aclprofiles/v/`) {
           return Promise.resolve(null)
         }
         return Promise.resolve({data: []})
@@ -882,7 +882,7 @@ describe.skip('DocumentList.vue', () => {
         if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/`) {
           return Promise.resolve({data: aclDocs})
         }
-        if (path === `/conf/api/v3/configs/master/d/aclprofiles/v/`) {
+        if (path === `/conf/api/v3/configs/prod/d/aclprofiles/v/`) {
           return Promise.resolve({data: null})
         }
         return Promise.resolve({data: []})
@@ -903,7 +903,7 @@ describe.skip('DocumentList.vue', () => {
       const wantedVersion = {
         version: '7f8a987c8e5e9db7c734ac8841c543d5bc5d9657',
       }
-      const wantedPath = `/conf/api/v3/configs/master/d/aclprofiles/v/${wantedVersion.version}/revert/`
+      const wantedPath = `/conf/api/v3/configs/prod/d/aclprofiles/v/${wantedVersion.version}/revert/`
       const putSpy = jest.spyOn(axios, 'put')
       putSpy.mockImplementation(() => Promise.resolve())
       const gitHistory = wrapper.findComponent(GitHistory)
@@ -943,7 +943,7 @@ describe.skip('DocumentList.vue', () => {
     test('should load correct default branch if got non existent branch in route params', (done) => {
       router.push('/list/random123/random123')
       setImmediate(() => {
-        expect(wrapper.vm.selectedBranch).toEqual('master')
+        expect(wrapper.vm.selectedBranch).toEqual('prod')
         expect(rbzTable.vm.data[0].name).toEqual('API Discovery')
         done()
       })
@@ -952,7 +952,7 @@ describe.skip('DocumentList.vue', () => {
     test('should load correct default branch if none given in route params', (done) => {
       router.push('/list')
       setImmediate(() => {
-        expect(wrapper.vm.selectedBranch).toEqual('master')
+        expect(wrapper.vm.selectedBranch).toEqual('prod')
         expect(rbzTable.vm.data[0].name).toEqual('API Discovery')
         done()
       })
@@ -977,7 +977,7 @@ describe.skip('DocumentList.vue', () => {
     })
 
     test('should load correct data when changing doc type', (done) => {
-      router.push('/list/master/contentfilterprofiles')
+      router.push('/list/prod/contentfilterprofiles')
       setImmediate(() => {
         expect(wrapper.vm.selectedDocType).toEqual('contentfilterprofiles')
         expect(rbzTable.vm.data[0].name).toEqual('content filter')
@@ -987,7 +987,7 @@ describe.skip('DocumentList.vue', () => {
 
     test('should not load new data if new route is not DocumentList', (done) => {
       const spy = jest.spyOn(wrapper.vm, 'setSelectedDataFromRouteParams')
-      router.push('/config/master/contentfilterprofiles')
+      router.push('/config/prod/contentfilterprofiles')
       setImmediate(() => {
         expect(spy).not.toHaveBeenCalled()
         done()
@@ -1230,10 +1230,10 @@ describe.skip('DocumentList.vue', () => {
     describe('new document button', () => {
       test('should be able to add a new aclprofiles document', (done) => {
         mockRoute.params = {
-          branch: 'master',
+          branch: 'prod',
           doc_type: 'aclprofiles',
         }
-        mockRoute.path = `/list/master/aclprofiles`
+        mockRoute.path = `/list/prod/aclprofiles`
         wrapper = mount(DocumentList, {
           global: {
             mocks: {
@@ -1250,17 +1250,17 @@ describe.skip('DocumentList.vue', () => {
           postSpy.mockImplementation(() => Promise.resolve())
           const rbzTable = wrapper.findComponent(RbzTable)
           rbzTable.vm.$emit('new-button-clicked')
-          expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/aclprofiles/e/`, newACLProfilesDoc)
+          expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/aclprofiles/e/`, newACLProfilesDoc)
           done()
         })
       })
 
       test('should be able to add a new globalfilters document', (done) => {
         mockRoute.params = {
-          branch: 'master',
+          branch: 'prod',
           doc_type: 'globalfilters',
         }
-        mockRoute.path = `/list/master/globalfilters`
+        mockRoute.path = `/list/prod/globalfilters`
         wrapper = mount(DocumentList, {
           global: {
             mocks: {
@@ -1277,17 +1277,17 @@ describe.skip('DocumentList.vue', () => {
           postSpy.mockImplementation(() => Promise.resolve())
           const rbzTable = wrapper.findComponent(RbzTable)
           rbzTable.vm.$emit('new-button-clicked')
-          expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/globalfilters/e/`, newGlobalFilterDoc)
+          expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/globalfilters/e/`, newGlobalFilterDoc)
           done()
         })
       })
 
       test('should be able to add a new contentfilterprofiles document', (done) => {
         mockRoute.params = {
-          branch: 'master',
+          branch: 'prod',
           doc_type: 'contentfilterprofiles',
         }
-        mockRoute.path = `/list/master/contentfilterprofiles`
+        mockRoute.path = `/list/prod/contentfilterprofiles`
         wrapper = mount(DocumentList, {
           global: {
             mocks: {
@@ -1303,7 +1303,7 @@ describe.skip('DocumentList.vue', () => {
           postSpy.mockImplementation(() => Promise.resolve())
           const rbzTable = wrapper.findComponent(RbzTable)
           rbzTable.vm.$emit('new-button-clicked')
-          const wantedPath = `/conf/api/v3/configs/master/d/contentfilterprofiles/e/`
+          const wantedPath = `/conf/api/v3/configs/prod/d/contentfilterprofiles/e/`
           expect(postSpy).toHaveBeenCalledWith(wantedPath, newContentFilterProfilesDoc)
           done()
         })
@@ -1311,10 +1311,10 @@ describe.skip('DocumentList.vue', () => {
 
       test('should be able to add a new ratelimits document', (done) => {
         mockRoute.params = {
-          branch: 'master',
+          branch: 'prod',
           doc_type: 'ratelimits',
         }
-        mockRoute.path = `/list/master/ratelimits`
+        mockRoute.path = `/list/prod/ratelimits`
         wrapper = mount(DocumentList, {
           global: {
             mocks: {
@@ -1330,17 +1330,17 @@ describe.skip('DocumentList.vue', () => {
           postSpy.mockImplementation(() => Promise.resolve())
           const rbzTable = wrapper.findComponent(RbzTable)
           rbzTable.vm.$emit('new-button-clicked')
-          expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/ratelimits/e/`, newRateLimitsDoc)
+          expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/ratelimits/e/`, newRateLimitsDoc)
           done()
         })
       })
 
       test('should be able to add a new flowcontrol document', (done) => {
         mockRoute.params = {
-          branch: 'master',
+          branch: 'prod',
           doc_type: 'flowcontrol',
         }
-        mockRoute.path = `/list/master/flowcontrol`
+        mockRoute.path = `/list/prod/flowcontrol`
         wrapper = mount(DocumentList, {
           global: {
             mocks: {
@@ -1356,17 +1356,17 @@ describe.skip('DocumentList.vue', () => {
           postSpy.mockImplementation(() => Promise.resolve())
           const rbzTable = wrapper.findComponent(RbzTable)
           rbzTable.vm.$emit('new-button-clicked')
-          expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/d/flowcontrol/e/`, newFlowControlDoc)
+          expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/d/flowcontrol/e/`, newFlowControlDoc)
           done()
         })
       })
 
       test('should be able to add a new contentfilterrules document', (done) => {
         mockRoute.params = {
-          branch: 'master',
+          branch: 'prod',
           doc_type: 'contentfilterrules',
         }
-        mockRoute.path = `/list/master/contentfilterrules`
+        mockRoute.path = `/list/prod/contentfilterrules`
         wrapper = mount(DocumentList, {
           global: {
             mocks: {
@@ -1382,7 +1382,7 @@ describe.skip('DocumentList.vue', () => {
           postSpy.mockImplementation(() => Promise.resolve())
           const rbzTable = wrapper.findComponent(RbzTable)
           rbzTable.vm.$emit('new-button-clicked')
-          const wantedPath = `/conf/api/v3/configs/master/d/contentfilterrules/e/`
+          const wantedPath = `/conf/api/v3/configs/prod/d/contentfilterrules/e/`
           expect(postSpy).toHaveBeenCalledWith(wantedPath, newContentFilterRulesDoc)
           done()
         })
@@ -1393,9 +1393,9 @@ describe.skip('DocumentList.vue', () => {
       test('should redirect to correct document when clicking on edit document button', async () => {
         const rbzTable = wrapper.findComponent(RbzTable)
         rbzTable.vm.$emit('row-button-clicked', aclDocs[1]['id'])
-        expect(mockRouter.push).toHaveBeenCalledWith(`/config/master/aclprofiles/${aclDocs[1]['id']}`)
+        expect(mockRouter.push).toHaveBeenCalledWith(`/config/prod/aclprofiles/${aclDocs[1]['id']}`)
         rbzTable.vm.$emit('row-button-clicked', aclDocs[0]['id'])
-        expect(mockRouter.push).toHaveBeenCalledWith(`/config/master/aclprofiles/${aclDocs[0]['id']}`)
+        expect(mockRouter.push).toHaveBeenCalledWith(`/config/prod/aclprofiles/${aclDocs[0]['id']}`)
       })
     })
   })
@@ -1404,10 +1404,10 @@ describe.skip('DocumentList.vue', () => {
     const buildColumnOptionsTest = (docType: DocumentType) => {
       test(`should load correct column options for ${docType}`, (done) => {
         mockRoute.params = {
-          branch: 'master',
+          branch: 'prod',
           doc_type: docType,
         }
-        mockRoute.path = `/list/master/${docType}`
+        mockRoute.path = `/list/prod/${docType}`
         wrapper = mount(DocumentList, {
           global: {
             mocks: {

--- a/src/views/__tests__/Publish.spec.ts
+++ b/src/views/__tests__/Publish.spec.ts
@@ -29,7 +29,7 @@ describe.skip('Publish.vue', () => {
             'parents': [
               '16379cdf39501574b4a2f5a227b82a4454884b84',
             ],
-            'message': 'Create config [master]\n',
+            'message': 'Create config [prod]\n',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -55,8 +55,8 @@ describe.skip('Publish.vue', () => {
         'version': '1662043d2a18d6ad2c9c94d6f826593ff5506354',
       },
       {
-        'id': 'master',
-        'description': 'Update entry [__default__] of document [aclprofiles]',
+        'id': 'prod',
+        'description': 'Update entry [__acldefault__] of document [aclprofiles]',
         'date': '2020-11-10T15:49:17+02:00',
         'logs': [
           {
@@ -65,7 +65,7 @@ describe.skip('Publish.vue', () => {
             'parents': [
               'fc47a6cd9d7f254dd97875a04b87165cc484e075',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -75,7 +75,7 @@ describe.skip('Publish.vue', () => {
             'parents': [
               '5aba4a5b9d6faea1896ee8965c7aa651f76af63c',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -85,7 +85,7 @@ describe.skip('Publish.vue', () => {
             'parents': [
               '277c5d7bd0e2eb4b9d2944f7eefdfadf37ba8581',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -95,7 +95,7 @@ describe.skip('Publish.vue', () => {
             'parents': [
               '878b47deeddac94625fe7c759786f2df885ec541',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -105,7 +105,7 @@ describe.skip('Publish.vue', () => {
             'parents': [
               '93c180513fe7edeaf1c0ca69a67aa2a11374da4f',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -115,7 +115,7 @@ describe.skip('Publish.vue', () => {
             'parents': [
               '1662043d2a18d6ad2c9c94d6f826593ff5506354',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -125,7 +125,7 @@ describe.skip('Publish.vue', () => {
             'parents': [
               '16379cdf39501574b4a2f5a227b82a4454884b84',
             ],
-            'message': 'Create config [master]\n',
+            'message': 'Create config [prod]\n',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -156,7 +156,7 @@ describe.skip('Publish.vue', () => {
         {'name': 'devops', 'url': 's3://curiefense-test01/devops'},
         {'name': 'prod', 'url': 's3://curiefense-test01/prod'},
       ],
-      'branch_buckets': [{'name': 'master', 'buckets': ['prod']}, {'name': 'devops', 'buckets': ['devops']}],
+      'branch_buckets': [{'name': 'prod', 'buckets': ['prod']}, {'name': 'devops', 'buckets': ['devops']}],
     }
     jest.spyOn(axios, 'get').mockImplementation((path) => {
       if (path === '/conf/api/v3/configs/') {
@@ -210,7 +210,7 @@ describe.skip('Publish.vue', () => {
       'parents': [
         '16379cdf39501574b4a2f5a227b82a4454884b84',
       ],
-      'message': 'Create config [master]\n',
+      'message': 'Create config [prod]\n',
       'email': 'curiefense@reblaze.com',
       'author': 'Curiefense API',
     }]
@@ -237,7 +237,7 @@ describe.skip('Publish.vue', () => {
         {'name': 'prod', 'url': 's3://curiefense-test01/prod'},
         {'name': 'devops', 'url': 's3://curiefense-test01/devops'},
       ],
-      'branch_buckets': [{'name': 'master', 'buckets': ['prod', 'fake']}, {'name': 'devops', 'buckets': ['devops']}],
+      'branch_buckets': [{'name': 'prod', 'buckets': ['prod', 'fake']}, {'name': 'devops', 'buckets': ['devops']}],
     }
     await nextTick()
     const branchSelection = wrapper.find('.branch-selection')
@@ -349,7 +349,7 @@ describe.skip('Publish.vue', () => {
           {'name': 'prod', 'url': 's3://curiefense-test01/prod'},
           {'name': 'devops', 'url': 's3://curiefense-test01/devops'},
         ],
-        'branch_buckets': [{'name': 'master'}, {'name': 'devops'}],
+        'branch_buckets': [{'name': 'prod'}, {'name': 'devops'}],
       }
       wrapper = mount(Publish)
       await nextTick()
@@ -368,7 +368,7 @@ describe.skip('Publish.vue', () => {
           {'name': 'prod', 'url': 's3://curiefense-test01/prod'},
           {'name': 'devops', 'url': 's3://curiefense-test01/devops'},
         ],
-        'branch_buckets': [{'name': 'master1'}, {'name': 'devops1'}],
+        'branch_buckets': [{'name': 'prod1'}, {'name': 'devops1'}],
       }
       wrapper = mount(Publish)
       await nextTick()

--- a/src/views/__tests__/SystemDBEditor.spec.ts
+++ b/src/views/__tests__/SystemDBEditor.spec.ts
@@ -24,7 +24,7 @@ describe('SystemDBEditor.vue', () => {
         'name': 'devops',
         'url': 's3://curiefense-test01/devops',
       }],
-      'branch_buckets': [{'name': 'master', 'buckets': ['prod']}, {'name': 'devops', 'buckets': ['devops']}],
+      'branch_buckets': [{'name': 'prod', 'buckets': ['prod']}, {'name': 'devops', 'buckets': ['devops']}],
     }
     dbData = {
       'publishinfo': publishInfoData,

--- a/src/views/__tests__/VersionControl.spec.ts
+++ b/src/views/__tests__/VersionControl.spec.ts
@@ -18,8 +18,8 @@ describe.skip('VersionControl.vue', () => {
   beforeEach(() => {
     gitData = [
       {
-        'id': 'master',
-        'description': 'Update entry [__default__] of document [aclprofiles]',
+        'id': 'prod',
+        'description': 'Update entry [__acldefault__] of document [aclprofiles]',
         'date': '2020-11-10T15:49:17+02:00',
         'logs': [
           {
@@ -28,7 +28,7 @@ describe.skip('VersionControl.vue', () => {
             'parents': [
               'fc47a6cd9d7f254dd97875a04b87165cc484e075',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -38,7 +38,7 @@ describe.skip('VersionControl.vue', () => {
             'parents': [
               '5aba4a5b9d6faea1896ee8965c7aa651f76af63c',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -48,7 +48,7 @@ describe.skip('VersionControl.vue', () => {
             'parents': [
               '277c5d7bd0e2eb4b9d2944f7eefdfadf37ba8581',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -58,7 +58,7 @@ describe.skip('VersionControl.vue', () => {
             'parents': [
               '878b47deeddac94625fe7c759786f2df885ec541',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -68,7 +68,7 @@ describe.skip('VersionControl.vue', () => {
             'parents': [
               '93c180513fe7edeaf1c0ca69a67aa2a11374da4f',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -78,7 +78,7 @@ describe.skip('VersionControl.vue', () => {
             'parents': [
               '1662043d2a18d6ad2c9c94d6f826593ff5506354',
             ],
-            'message': 'Update entry [__default__] of document [aclprofiles]',
+            'message': 'Update entry [__acldefault__] of document [aclprofiles]',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -88,7 +88,7 @@ describe.skip('VersionControl.vue', () => {
             'parents': [
               '16379cdf39501574b4a2f5a227b82a4454884b84',
             ],
-            'message': 'Create config [master]\n',
+            'message': 'Create config [prod]\n',
             'email': 'curiefense@reblaze.com',
             'author': 'Curiefense API',
           },
@@ -134,13 +134,13 @@ describe.skip('VersionControl.vue', () => {
       if (path === '/conf/api/v3/configs/') {
         return Promise.resolve({data: gitData})
       }
-      if (path === '/conf/api/v3/configs/master/') {
+      if (path === '/conf/api/v3/configs/prod/') {
         return Promise.resolve({data: gitData[0]})
       }
       if (path === '/conf/api/v3/configs/zzz_branch/') {
         return Promise.resolve({data: gitData[1]})
       }
-      if (path === '/conf/api/v3/configs/master/v/') {
+      if (path === '/conf/api/v3/configs/prod/v/') {
         return Promise.resolve({data: gitData[0].logs})
       }
       if (path === '/conf/api/v3/configs/zzz_branch/v/') {
@@ -197,8 +197,8 @@ describe.skip('VersionControl.vue', () => {
   test('should display correct singular amount of branches', (done) => {
     gitData = [
       {
-        'id': 'master',
-        'description': 'Update entry [__default__] of document [aclprofiles]',
+        'id': 'prod',
+        'description': 'Update entry [__acldefault__] of document [aclprofiles]',
         'date': '2020-11-10T15:49:17+02:00',
         'logs': [{
           'version': '7dd9580c00bef1049ee9a531afb13db9ef3ee956',
@@ -206,7 +206,7 @@ describe.skip('VersionControl.vue', () => {
           'parents': [
             'fc47a6cd9d7f254dd97875a04b87165cc484e075',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         }],
@@ -217,10 +217,10 @@ describe.skip('VersionControl.vue', () => {
       if (path === '/conf/api/v3/configs/') {
         return Promise.resolve({data: gitData})
       }
-      if (path === '/conf/api/v3/configs/master/') {
+      if (path === '/conf/api/v3/configs/prod/') {
         return Promise.resolve({data: gitData[0]})
       }
-      if (path === '/conf/api/v3/configs/master/v/') {
+      if (path === '/conf/api/v3/configs/prod/v/') {
         return Promise.resolve({data: gitData[0].logs})
       }
       return Promise.resolve({data: []})
@@ -237,8 +237,8 @@ describe.skip('VersionControl.vue', () => {
   test('should display correct singular amount of commits', (done) => {
     gitData = [
       {
-        'id': 'master',
-        'description': 'Update entry [__default__] of document [aclprofiles]',
+        'id': 'prod',
+        'description': 'Update entry [__acldefault__] of document [aclprofiles]',
         'date': '2020-11-10T15:49:17+02:00',
         'logs': [{
           'version': '7dd9580c00bef1049ee9a531afb13db9ef3ee956',
@@ -246,7 +246,7 @@ describe.skip('VersionControl.vue', () => {
           'parents': [
             'fc47a6cd9d7f254dd97875a04b87165cc484e075',
           ],
-          'message': 'Update entry [__default__] of document [aclprofiles]',
+          'message': 'Update entry [__acldefault__] of document [aclprofiles]',
           'email': 'curiefense@reblaze.com',
           'author': 'Curiefense API',
         }],
@@ -257,10 +257,10 @@ describe.skip('VersionControl.vue', () => {
       if (path === '/conf/api/v3/configs/') {
         return Promise.resolve({data: gitData})
       }
-      if (path === '/conf/api/v3/configs/master/') {
+      if (path === '/conf/api/v3/configs/prod/') {
         return Promise.resolve({data: gitData[0]})
       }
-      if (path === '/conf/api/v3/configs/master/v/') {
+      if (path === '/conf/api/v3/configs/prod/v/') {
         return Promise.resolve({data: gitData[0].logs})
       }
       return Promise.resolve({data: []})
@@ -329,11 +329,11 @@ describe.skip('VersionControl.vue', () => {
     const gitHistory = wrapper.findComponent(GitHistory)
     gitHistory.vm.$emit('restore-version', wantedVersion)
     await nextTick()
-    expect(putSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/v/${wantedVersion.version}/revert/`)
+    expect(putSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/v/${wantedVersion.version}/revert/`)
   })
 
   test('should attempt to download branch when download button is clicked', async () => {
-    const wantedFileName = 'master'
+    const wantedFileName = 'prod'
     const wantedFileType = 'json'
     const wantedFileData = gitData[0]
     const downloadFileSpy = jest.spyOn(Utils, 'downloadFile')
@@ -395,7 +395,7 @@ describe.skip('VersionControl.vue', () => {
         if (path === '/conf/api/v3/configs/') {
           return Promise.resolve({data: gitData})
         }
-        if (path === '/conf/api/v3/configs/master/') {
+        if (path === '/conf/api/v3/configs/prod/') {
           return Promise.resolve(null)
         }
         return Promise.resolve({data: {}})
@@ -414,7 +414,7 @@ describe.skip('VersionControl.vue', () => {
         if (path === '/conf/api/v3/configs/') {
           return Promise.resolve({data: gitData})
         }
-        if (path === '/conf/api/v3/configs/master/') {
+        if (path === '/conf/api/v3/configs/prod/') {
           return Promise.resolve({data: null})
         }
         return Promise.resolve({data: {}})
@@ -432,10 +432,10 @@ describe.skip('VersionControl.vue', () => {
       if (path === '/conf/api/v3/configs/') {
         return Promise.resolve({data: gitData})
       }
-      if (path === '/conf/api/v3/configs/master/') {
+      if (path === '/conf/api/v3/configs/prod/') {
         return Promise.resolve({data: gitData[0]})
       }
-      if (path === '/conf/api/v3/configs/master/v/') {
+      if (path === '/conf/api/v3/configs/prod/v/') {
         return Promise.resolve(null)
       }
       return Promise.resolve({data: []})
@@ -450,10 +450,10 @@ describe.skip('VersionControl.vue', () => {
       if (path === '/conf/api/v3/configs/') {
         return Promise.resolve({data: gitData})
       }
-      if (path === '/conf/api/v3/configs/master/') {
+      if (path === '/conf/api/v3/configs/prod/') {
         return Promise.resolve({data: gitData[0]})
       }
-      if (path === '/conf/api/v3/configs/master/v/') {
+      if (path === '/conf/api/v3/configs/prod/v/') {
         return Promise.resolve({data: null})
       }
       return Promise.resolve({data: []})
@@ -499,7 +499,7 @@ describe.skip('VersionControl.vue', () => {
       const forkBranchSaveButton = wrapper.find('.fork-branch-confirm')
       await forkBranchNameInput.setValue(newBranchName)
       await forkBranchSaveButton.trigger('click')
-      expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/master/clone/${newBranchName}/`, {
+      expect(postSpy).toHaveBeenCalledWith(`/conf/api/v3/configs/prod/clone/${newBranchName}/`, {
         'description': 'string',
         'id': 'string',
       })


### PR DESCRIPTION
Remove outdated `master` term from the system unit tests and replace it with `Prod` (Production)
Change default ACL Profile id from `__default__` to `__acldefault__`
Change delete button to be disabled for entities with id starting with `__`, `rbz-`, `action-`, `rl-`, `dr_`
Fix bug where no branch is loaded if initial system load is in a page without branch in route (Will now load first branch if none loaded)
Add option `None` for MobileSDKs dropdown in Web Proxy
Add `id` field to Routing Profile map entry

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>