### PR TITLE
Various UI changes

### DIFF
--- a/src/assets/DatasetsUtils.ts
+++ b/src/assets/DatasetsUtils.ts
@@ -206,6 +206,8 @@ const newDocEntryFactory: { [key: string]: Function } = {
       'id': id,
       'name': 'New Security Policy',
       'match': `${id}.example.com`,
+      'description': 'New Security Policy Description and Remarks',
+      'tags': [],
       'map': [
         {
           'id': generateUUID2(),
@@ -303,6 +305,7 @@ const newDocEntryFactory: { [key: string]: Function } = {
       'include': ['all'],
       'exclude': [],
       'ttl': 7200,
+      'tags': [],
       'target': 'remote_addr',
     }
   },

--- a/src/components/LabeledTags.vue
+++ b/src/components/LabeledTags.vue
@@ -40,7 +40,7 @@ export default defineComponent({
   border: 1px solid #fff;
   border-radius: 10px;
   margin-right: 0.25rem;
-  max-width: 90vh;
+  max-width: 90%;
   padding: 0.05rem 0.5rem;
   width: fit-content;
 }

--- a/src/components/SecurityPoliciesConnections.vue
+++ b/src/components/SecurityPoliciesConnections.vue
@@ -6,9 +6,9 @@
       <tr>
         <th class="is-size-7 width-150px">Name</th>
         <th class="is-size-7 width-120px">ID</th>
-        <th class="is-size-7 ellipsis">Domain Match</th>
+        <th class="is-size-7 width-300px">Domain Match</th>
         <th class="is-size-7 width-300px">Entry Match</th>
-        <th class="is-size-7 width-80px has-text-centered">
+        <th class="is-size-7 width-70px has-text-centered">
           <a v-if="!newSecurityPolicyConnectionOpened"
               class="has-text-grey-dark is-small new-connection-button"
               data-qa="attach-to-site-btn"
@@ -87,7 +87,7 @@
         </template>
       </tr>
       <tr v-for="(connection, index) in connectedSecurityPoliciesEntries" :key="index">
-        <td class="is-size-7 is-vcentered py-3 width-200px connected-entry-row"
+        <td class="is-size-7 is-vcentered py-3 width-150px connected-entry-row"
             :title="connection[0]">
           <a title="Add new"
               class="security-policy-referral-button"
@@ -99,7 +99,7 @@
             :title="connection.id">
           {{ connection.id }}
         </td>
-        <td class="is-size-7 is-vcentered py-3 width-300px"
+        <td class="is-size-7 is-vcentered py-3 width-300px ellipsis"
             :title="connection.domainMatch">
           {{ connection.domainMatch }}
         </td>
@@ -107,7 +107,7 @@
             :title="connection.entryMatch">
           {{ connection.entryMatch }}
         </td>
-        <td class="is-size-7 is-vcentered width-80px height-50px">
+        <td class="is-size-7 is-vcentered width-70px height-50px">
             <span v-show="currentEntryDeleteIndex !== index">
             <a tabindex="0"
                 title="Remove connection to the Security Policy"

--- a/src/doc-editors/ACLEditor.vue
+++ b/src/doc-editors/ACLEditor.vue
@@ -60,8 +60,7 @@
                    data-qa="tag-input">
                 <tag-autocomplete-input :initial-tag="selectedDocTags"
                                         :selection-type="'multiple'"
-                                        @tag-changed="selectedDocTags = $event">
-                </tag-autocomplete-input>
+                                        @tag-changed="selectedDocTags = $event" />
               </div>
             </div>
           </div>
@@ -109,8 +108,7 @@
                                         :selection-type="'single'"
                                         :auto-focus="true"
                                         @keydown.esc="cancelAddNewTag"
-                                        @tag-submitted="addNewEntry(operation, $event)">
-                </tag-autocomplete-input>
+                                        @tag-submitted="addNewEntry(operation, $event)" />
               </td>
               <td class="is-size-7 width-20px">
                 <a title="add new entry"

--- a/src/doc-editors/ContentFilterProfileEditor.vue
+++ b/src/doc-editors/ContentFilterProfileEditor.vue
@@ -72,8 +72,7 @@
                data-qa="tag-input">
             <tag-autocomplete-input :initial-tag="selectedDocTags"
                                     :selection-type="'multiple'"
-                                    @tag-changed="selectedDocTags = $event">
-            </tag-autocomplete-input>
+                                    @tag-changed="selectedDocTags = $event" />
           </div>
         </div>
         <div class="field ignore-alphanumeric-input-field"

--- a/src/doc-editors/ContentFilterRulesEditor.vue
+++ b/src/doc-editors/ContentFilterRulesEditor.vue
@@ -81,8 +81,7 @@
                    data-qa="tag-input">
                 <tag-autocomplete-input :initial-tag="selectedDocTags"
                                         :selection-type="'multiple'"
-                                        @tag-changed="selectedDocTags = $event">
-                </tag-autocomplete-input>
+                                        @tag-changed="selectedDocTags = $event" />
               </div>
               <div class="is-size-7 document-automatic-tags">
                 Automatic Tags:

--- a/src/doc-editors/CustomResponseEditor.vue
+++ b/src/doc-editors/CustomResponseEditor.vue
@@ -40,7 +40,7 @@
               <select v-model="localDoc.type"
                       class="type-selection"
                       title="Switch type"
-                      @change="emitDocUpdate()">
+                      @change="normalizeParams()">
                 <option v-for="name in customResponseTypes"
                         :key="name"
                         :value="name">
@@ -56,8 +56,7 @@
               <tag-autocomplete-input :initial-tag="selectedDocTags"
                                       :selection-type="'multiple'"
                                       @tag-changed="selectedDocTags = $event"
-                                      class="document-autocomplete-input">
-              </tag-autocomplete-input>
+                                      class="document-autocomplete-input" />
             </div>
           </div>
         </div>

--- a/src/doc-editors/DynamicRulesEditor.vue
+++ b/src/doc-editors/DynamicRulesEditor.vue
@@ -135,8 +135,7 @@
                  data-qa="tag-input">
               <tag-autocomplete-input :initial-tag="selectedDocTags"
                                       :selection-type="'multiple'"
-                                      @tag-changed="selectedDocTags = $event">
-              </tag-autocomplete-input>
+                                      @tag-changed="selectedDocTags = $event" />
             </div>
           </div>
         </div>
@@ -181,8 +180,7 @@
                                             :selection-type="'single'"
                                             :auto-focus="true"
                                             @keydown.esc="cancelAddNewTag"
-                                            @tag-submitted="addNewTag(filter, $event)">
-                    </tag-autocomplete-input>
+                                            @tag-submitted="addNewTag(filter, $event)" />
                   </td>
                   <td class="is-size-7 width-20px">
                     <a title="add new entry"

--- a/src/doc-editors/FlowControlPolicyEditor.vue
+++ b/src/doc-editors/FlowControlPolicyEditor.vue
@@ -77,8 +77,7 @@
                  data-qa="tag-input">
               <tag-autocomplete-input :initial-tag="selectedDocTags"
                                       :selection-type="'multiple'"
-                                      @tag-changed="selectedDocTags = $event">
-              </tag-autocomplete-input>
+                                      @tag-changed="selectedDocTags = $event" />
             </div>
           </div>
           <div class="field textarea-field">
@@ -132,8 +131,7 @@
                                             :selection-type="'single'"
                                             :auto-focus="true"
                                             @keydown.esc="cancelAddNewTag"
-                                            @tag-submitted="addNewTag(filter, $event)">
-                    </tag-autocomplete-input>
+                                            @tag-submitted="addNewTag(filter, $event)" />
                   </td>
                   <td class="is-size-7 width-20px">
                     <a title="add new entry"

--- a/src/doc-editors/GlobalFilterListEditor.vue
+++ b/src/doc-editors/GlobalFilterListEditor.vue
@@ -68,8 +68,7 @@
               <tag-autocomplete-input :initial-tag="selectedDocTags"
                                       :selection-type="'multiple'"
                                       :editable="editable"
-                                      @tag-changed="selectedDocTags = $event">
-              </tag-autocomplete-input>
+                                      @tag-changed="selectedDocTags = $event" />
             </div>
           </div>
           <div class="field">

--- a/src/doc-editors/RateLimitsEditor.vue
+++ b/src/doc-editors/RateLimitsEditor.vue
@@ -62,8 +62,7 @@
                  data-qa="tag-input">
               <tag-autocomplete-input :initial-tag="selectedDocTags"
                                       :selection-type="'multiple'"
-                                      @tag-changed="selectedDocTags = $event">
-              </tag-autocomplete-input>
+                                      @tag-changed="selectedDocTags = $event" />
             </div>
           </div>
           <div class="group-key mb-3">
@@ -211,8 +210,7 @@
                                             :selection-type="'single'"
                                             :auto-focus="true"
                                             @keydown.esc="cancelAddNewTag"
-                                            @tag-submitted="addNewTag(filter, $event)">
-                    </tag-autocomplete-input>
+                                            @tag-submitted="addNewTag(filter, $event)" />
                   </td>
                   <td class="is-size-7 width-20px">
                     <a title="add new entry"

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -45,6 +45,8 @@
               <tag-autocomplete-input :initial-tag="selectedDocTags"
                                       :selection-type="'multiple'"
                                       @tag-changed="selectedDocTags = $event" />
+              <labeled-tags title="Automatic Tag"
+                            :tags="automaticTags" />
             </div>
           </div>
           <div class="field">
@@ -389,10 +391,11 @@ import {ACLProfile, ContentFilterProfile, RateLimit, SecurityPolicy, SecurityPol
 import {AxiosResponse} from 'axios'
 import Utils from '@/assets/Utils'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
+import LabeledTags from '@/components/LabeledTags.vue'
 
 export default defineComponent({
   name: 'SecurityPoliciesEditor',
-  components: {TagAutocompleteInput},
+  components: {LabeledTags, TagAutocompleteInput},
   props: {
     selectedDoc: Object,
     selectedBranch: String,
@@ -438,6 +441,11 @@ export default defineComponent({
         }) : []
         this.emitDocUpdate()
       },
+    },
+
+    automaticTags(): string[] {
+      const nameTag = `securitypolicy:${this.localDoc.name?.replace(/ /g, '-') || ''}`
+      return [nameTag]
     },
 
     isFormInvalid(): boolean {

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -22,7 +22,7 @@
           </div>
           <div class="field">
             <label class="label is-small">
-              Matching Names
+              Match Host/Authority Header
             </label>
             <div class="control has-icons-left">
               <input type="text"
@@ -38,6 +38,31 @@
               <span class="icon is-small is-left has-text-grey"><i class="fas fa-code"></i></span>
             </div>
           </div>
+          <div class="field">
+            <label class="label is-small">Tags</label>
+            <div class="control"
+                 data-qa="tag-input">
+              <tag-autocomplete-input :initial-tag="selectedDocTags"
+                                      :selection-type="'multiple'"
+                                      @tag-changed="selectedDocTags = $event" />
+            </div>
+          </div>
+          <div class="field">
+            <div class="field textarea-field">
+              <label class="label is-small">
+                Description
+              </label>
+              <div class="control">
+                <textarea class="is-small textarea document-description"
+                          data-qa="description-input"
+                          title="Document description"
+                          v-model="localDoc.description"
+                          @input="emitDocUpdate"
+                          rows="5">
+                </textarea>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <div class="field px-3">
@@ -50,7 +75,7 @@
             <th></th>
             <th>Name</th>
             <th>
-              <span>Match</span>
+              <span>Match Path</span>
               &nbsp;
               <span><i class="fas fa-sort-alpha-down"></i></span>
             </th>
@@ -363,10 +388,11 @@ import {defineComponent} from 'vue'
 import {ACLProfile, ContentFilterProfile, RateLimit, SecurityPolicy, SecurityPolicyEntryMatch} from '@/types'
 import {AxiosResponse} from 'axios'
 import Utils from '@/assets/Utils'
+import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 
 export default defineComponent({
   name: 'SecurityPoliciesEditor',
-
+  components: {TagAutocompleteInput},
   props: {
     selectedDoc: Object,
     selectedBranch: String,
@@ -397,6 +423,21 @@ export default defineComponent({
   computed: {
     localDoc(): SecurityPolicy {
       return _.cloneDeep(this.selectedDoc as SecurityPolicy)
+    },
+
+    selectedDocTags: {
+      get: function(): string {
+        if (this.localDoc.tags && this.localDoc.tags.length > 0) {
+          return this.localDoc.tags.join(' ')
+        }
+        return ''
+      },
+      set: function(tags: string): void {
+        this.localDoc.tags = tags.length > 0 ? _.map(tags.split(' '), (tag) => {
+          return tag.trim()
+        }) : []
+        this.emitDocUpdate()
+      },
     },
 
     isFormInvalid(): boolean {

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -154,7 +154,7 @@
                         </div>
                         <div class="field">
                           <label class="label is-small">
-                            Match
+                            Match Path
                           </label>
                           <div class="control has-icons-left">
                             <input class="input is-small current-entry-match"

--- a/src/doc-editors/__tests__/ContentFilterRulesEditor.spec.ts
+++ b/src/doc-editors/__tests__/ContentFilterRulesEditor.spec.ts
@@ -1,7 +1,8 @@
 // @ts-nocheck
 import ContentFilterRulesEditor from '@/doc-editors/ContentFilterRulesEditor.vue'
+import LabeledTags from '@/components/LabeledTags.vue'
 import {beforeEach, describe, expect, test} from '@jest/globals'
-import {shallowMount, VueWrapper} from '@vue/test-utils'
+import {mount, VueWrapper} from '@vue/test-utils'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import {ContentFilterRule} from '@/types'
 
@@ -20,7 +21,7 @@ describe('ContentFilterRulesEditor.vue', () => {
       'subcategory': 'statement injection',
       'tags': ['sqli'],
     }]
-    wrapper = shallowMount(ContentFilterRulesEditor, {
+    wrapper = mount(ContentFilterRulesEditor, {
       props: {
         selectedDoc: docs[0],
       },
@@ -63,44 +64,46 @@ describe('ContentFilterRulesEditor.vue', () => {
     })
 
     test('should have correct automatic tags displayed', () => {
-      const element = wrapper.find('.document-automatic-tags').element as HTMLDivElement
-      expect(element.innerHTML).toContain(`cf-rule-id:${docs[0].id.replace(/ /g, '-')}`)
-      expect(element.innerHTML).toContain(`cf-rule-risk:${docs[0].risk}`)
-      expect(element.innerHTML).toContain(`cf-rule-category:${docs[0].category.replace(/ /g, '-')}`)
-      expect(element.innerHTML).toContain(`cf-rule-subcategory:${docs[0].subcategory.replace(/ /g, '-')}`)
+      const labeledTagsComponent = wrapper.findComponent(LabeledTags)
+      expect(labeledTagsComponent.exists()).toBeTruthy()
+      expect(labeledTagsComponent.vm.tags).toContain(`cf-rule-id:${docs[0].id.replace(/ /g, '-')}`)
+      expect(labeledTagsComponent.vm.tags).toContain(`cf-rule-risk:${docs[0].risk}`)
+      expect(labeledTagsComponent.vm.tags).toContain(`cf-rule-category:${docs[0].category.replace(/ /g, '-')}`)
+      expect(labeledTagsComponent.vm.tags).toContain(`cf-rule-subcategory:${docs[0].subcategory.replace(/ /g, '-')}`)
+      expect(labeledTagsComponent.vm.tags).toEqual(wrapper.vm.automaticTags)
     })
 
     test('should have empty automatic tags displayed - empty id', () => {
       delete docs[0].id
-      wrapper = shallowMount(ContentFilterRulesEditor, {
+      wrapper = mount(ContentFilterRulesEditor, {
         props: {
           selectedDoc: docs[0],
         },
       })
-      const element = wrapper.find('.document-automatic-tags').element as HTMLDivElement
-      expect(element.innerHTML).toContain('cf-rule-id:\n')
+      const labeledTagsComponent = wrapper.findComponent(LabeledTags)
+      expect(labeledTagsComponent.vm.tags).toContain('cf-rule-id:')
     })
 
     test('should have empty automatic tags displayed - empty category', () => {
       delete docs[0].category
-      wrapper = shallowMount(ContentFilterRulesEditor, {
+      wrapper = mount(ContentFilterRulesEditor, {
         props: {
           selectedDoc: docs[0],
         },
       })
-      const element = wrapper.find('.document-automatic-tags').element as HTMLDivElement
-      expect(element.innerHTML).toContain('cf-rule-category:\n')
+      const labeledTagsComponent = wrapper.findComponent(LabeledTags)
+      expect(labeledTagsComponent.vm.tags).toContain('cf-rule-category:')
     })
 
     test('should have empty automatic tags displayed - empty subcategory', () => {
       delete docs[0].subcategory
-      wrapper = shallowMount(ContentFilterRulesEditor, {
+      wrapper = mount(ContentFilterRulesEditor, {
         props: {
           selectedDoc: docs[0],
         },
       })
-      const element = wrapper.find('.document-automatic-tags').element as HTMLDivElement
-      expect(element.innerHTML).toContain('cf-rule-subcategory:\n')
+      const labeledTagsComponent = wrapper.findComponent(LabeledTags)
+      expect(labeledTagsComponent.vm.tags).toContain('cf-rule-subcategory:')
     })
   })
 
@@ -132,7 +135,7 @@ describe('ContentFilterRulesEditor.vue', () => {
 
     test('should set tags input to be an empty string if document tags do not exist', () => {
       delete docs[0].tags
-      wrapper = shallowMount(ContentFilterRulesEditor, {
+      wrapper = mount(ContentFilterRulesEditor, {
         props: {
           selectedDoc: docs[0],
         },
@@ -143,7 +146,7 @@ describe('ContentFilterRulesEditor.vue', () => {
 
     test('should set tags input to be an empty string if document tags is empty', () => {
       docs[0].tags = []
-      wrapper = shallowMount(ContentFilterRulesEditor, {
+      wrapper = mount(ContentFilterRulesEditor, {
         props: {
           selectedDoc: docs[0],
         },

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -169,6 +169,8 @@ declare module CuriefenseClient {
     id: string
     name: string
     match: string
+    description: string
+    tags: string[]
     map: SecurityPolicyEntryMatch[]
   }
 
@@ -190,6 +192,7 @@ declare module CuriefenseClient {
     exclude: string[]
     include: string[]
     ttl: number,
+    tags: string[],
     target: DynamicRuleTargetOptionType
   }
 

--- a/src/views/MainComponent.vue
+++ b/src/views/MainComponent.vue
@@ -10,7 +10,8 @@
           <side-menu></side-menu>
         </div>
         <div class="column">
-          <div class="card is-fullheight has-overflow-y-auto">
+          <div class="card is-fullheight has-overflow-y-auto"
+          ref="viewCardScroll">
             <router-view></router-view>
           </div>
         </div>
@@ -30,6 +31,16 @@ import {useBranchesStore} from '@/stores/BranchesStore'
 export default defineComponent({
   name: 'MainComponent',
   components: {HeaderMain, SideMenu},
+  watch: {
+    $route: {
+      handler: async function(val, oldVal) {
+        if (val && val !== oldVal) {
+          this.$refs.viewCardScroll.scrollTop = 0
+        }
+      },
+      deep: true,
+    },
+  },
   computed: {
     ...mapStores(useBranchesStore),
   },

--- a/src/views/documentListConst.ts
+++ b/src/views/documentListConst.ts
@@ -4,7 +4,7 @@ import {
   ColumnOptionsMap,
   ContentFilterProfile,
   ContentFilterRule,
-  CustomResponse,
+  CustomResponse, DynamicRule,
   FlowControlPolicy,
   GlobalFilter,
   RateLimit,
@@ -109,46 +109,60 @@ export const COLUMN_OPTIONS_MAP: ColumnOptionsMap = {
       classes: 'width-120px',
     },
     {
-      title: 'Matching Names',
-      fieldNames: ['match'],
+      title: 'Description',
+      fieldNames: ['description'],
       isSortable: true,
       isSearchable: true,
       classes: 'ellipsis',
     },
     {
-      title: 'Rate Limit Rules',
-      fieldNames: ['map'],
-      displayFunction: (item: SecurityPolicy) => {
-        const amount = _.sumBy(item?.map, (mapEntry: SecurityPolicyEntryMatch) => {
-          return mapEntry.limit_ids.length
-        })
-        return amount.toString()
-      },
-      classes: 'width-120px',
+      title: 'Matching Names',
+      fieldNames: ['match'],
+      isSortable: true,
+      isSearchable: true,
+      classes: 'width-150px ellipsis',
     },
     {
-      title: 'Active ACL Profiles',
-      fieldNames: ['map'],
+      title: 'Tags',
+      fieldNames: ['tags'],
       displayFunction: (item: SecurityPolicy) => {
-        const active = item?.map?.filter((mapEntry: SecurityPolicyEntryMatch) => {
-          return mapEntry.acl_active
-        }).length
-        const total = item?.map?.length
-        return `${active} out of ${total}`
+        return item?.tags?.join('\n')
       },
-      classes: 'width-120px',
+      isSortable: true,
+      isSearchable: true,
+      classes: 'width-80px',
     },
     {
-      title: 'Active Content Filter Profiles',
+      title: 'Connected Profiles & Rules',
       fieldNames: ['map'],
       displayFunction: (item: SecurityPolicy) => {
-        const active = item?.map?.filter((mapEntry: SecurityPolicyEntryMatch) => {
-          return mapEntry.acl_active
-        }).length
-        const total = item?.map?.length
-        return `${active} out of ${total}`
+        const getRateLimitsAmount = () => {
+          const amount = _.sumBy(item?.map, (mapEntry: SecurityPolicyEntryMatch) => {
+            return mapEntry.limit_ids.length
+          })
+          return `Rate Limit: ${amount} total`
+        }
+        const getActiveACLs = () => {
+          const active = item?.map?.filter((mapEntry: SecurityPolicyEntryMatch) => {
+            return mapEntry.acl_active
+          }).length
+          const total = item?.map?.length
+          return `ACL: ${active} out of ${total} active`
+        }
+        const getActiveContentFilters = () => {
+          const active = item?.map?.filter((mapEntry: SecurityPolicyEntryMatch) => {
+            return mapEntry.acl_active
+          }).length
+          const total = item?.map?.length
+          return `Content Filter: ${active} out of ${total} active`
+        }
+        return [
+          getActiveContentFilters(),
+          getActiveACLs(),
+          getRateLimitsAmount(),
+        ].join('\n')
       },
-      classes: 'width-180px',
+      classes: 'width-200px white-space-pre ellipsis',
     },
   ],
   'ratelimits': [
@@ -366,7 +380,7 @@ export const COLUMN_OPTIONS_MAP: ColumnOptionsMap = {
       title: 'Tags',
       fieldNames: ['tags'],
       displayFunction: (item: ContentFilterRule) => {
-        return item?.tags?.join(', ')
+        return item?.tags?.join('\n')
       },
       isSortable: true,
       isSearchable: true,
@@ -414,6 +428,16 @@ export const COLUMN_OPTIONS_MAP: ColumnOptionsMap = {
       isSortable: true,
       isSearchable: true,
       classes: 'ellipsis',
+    },
+    {
+      title: 'Tags',
+      fieldNames: ['tags'],
+      displayFunction: (item: DynamicRule) => {
+        return item?.tags?.join('\n')
+      },
+      isSortable: true,
+      isSearchable: true,
+      classes: 'width-80px',
     },
     {
       title: 'Timeframe',

--- a/src/views/documentListConst.ts
+++ b/src/views/documentListConst.ts
@@ -4,7 +4,7 @@ import {
   ColumnOptionsMap,
   ContentFilterProfile,
   ContentFilterRule,
-  CustomResponse, DynamicRule,
+  CustomResponse,
   FlowControlPolicy,
   GlobalFilter,
   RateLimit,
@@ -428,16 +428,6 @@ export const COLUMN_OPTIONS_MAP: ColumnOptionsMap = {
       isSortable: true,
       isSearchable: true,
       classes: 'ellipsis',
-    },
-    {
-      title: 'Tags',
-      fieldNames: ['tags'],
-      displayFunction: (item: DynamicRule) => {
-        return item?.tags?.join('\n')
-      },
-      isSortable: true,
-      isSearchable: true,
-      classes: 'width-80px',
     },
     {
       title: 'Timeframe',


### PR DESCRIPTION
Add automatic scroll to the top of the page on page navigation
Fix issue where Rate Limits editor was wider than all the other screens
Fix issue where Custom Response editor did not reset params on type change
Change all TagAutocompleteInput html tags to be self closing
Add `Description` field to Security Policies editor
Add `Tags` field to Security Policies editor
Add `Description` and `Tags` columns to Security Policies list view
Change labels in Security Policies editor
Add automatic tag to Security Policy editor

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>