### PR TITLE
Hackathon fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
     <script src="/static/uPlot.iife.min.js"></script>
     <script defer src="/static/fa-531.js"></script>
 
-    <title>Curiefense Config Machine</title>
+    <title>Reblaze Console</title>
   </head>
   <body class="is-fullheight">
     <noscript>

--- a/src/assets/DatasetsUtils.ts
+++ b/src/assets/DatasetsUtils.ts
@@ -1,7 +1,7 @@
 import {
   ACLProfile,
   BackendService,
-  CloudFunction,
+  EdgeFunction,
   ContentFilterProfile,
   ContentFilterRule,
   CustomResponse,
@@ -10,7 +10,7 @@ import {
   GlobalFilter,
   HttpRequestMethods,
   MobileSDK,
-  ProxyTemplate,
+  ConfigTemplate,
   RateLimit,
   RoutingProfile,
   SecurityPolicy,
@@ -60,8 +60,8 @@ const titles: { [key: string]: string } = {
   'contentfilterprofiles-singular': 'Content Filter Profile',
   'contentfilterrules': 'Content Filter Rules',
   'contentfilterrules-singular': 'Content Filter Rule',
-  'cloud-functions': 'Cloud Functions',
-  'cloud-functions-singular': 'Cloud Function',
+  'cloud-functions': 'Edge Functions',
+  'cloud-functions-singular': 'Edge Function',
   'globalfilters': 'Global Filters',
   'globalfilters-singular': 'Global Filter',
   'quarantined': 'Quarantined List',
@@ -74,16 +74,16 @@ const titles: { [key: string]: string } = {
   'routing-profiles-singular': 'Routing Profile',
   'mobile-sdks': 'MobileSDKs',
   'mobile-sdks-singular': 'MobileSDK',
-  'proxy-templates': 'Proxy Templates',
-  'proxy-templates-singular': 'Proxy Template',
-  'sites': 'Web Proxies',
-  'sites-singular': 'Web Proxy',
+  'proxy-templates': 'Config Templates',
+  'proxy-templates-singular': 'Config Template',
+  'sites': 'Server Groups',
+  'sites-singular': 'Server Group',
   'backends': 'Backends Services',
   'backends-singular': 'Backend Service',
   'report': 'Report',
   'ignore': 'Ignore',
-  'request1': 'Request',
-  'response0': 'Response',
+  'request': 'Request',
+  'response': 'Response',
 }
 
 const dynamicRuleTargets = {
@@ -125,7 +125,7 @@ const newDocEntryFactory: { [key: string]: Function } = {
       'id': generateUUID2(),
       'name': 'New ACL Profile',
       'description': 'New ACL Profile Description and Remarks',
-      'action': 'monitor',
+      'action': 'action-acl-block',
       'tags': [],
       'allow': [],
       'allow_bot': [],
@@ -141,7 +141,7 @@ const newDocEntryFactory: { [key: string]: Function } = {
       'id': generateUUID2(),
       'name': 'New Content Filter Profile',
       'description': 'New Content Filter Profile Description and Remarks',
-      'action': 'monitor',
+      'action': 'action-contentfilter-block',
       'tags': [],
       'ignore_body': true,
       'ignore_alphanum': true,
@@ -192,7 +192,7 @@ const newDocEntryFactory: { [key: string]: Function } = {
       'description': 'New Global Filter Description and Remarks',
       'active': false,
       'tags': ['trusted'],
-      'action': 'monitor',
+      'action': 'action-global-filter-block',
       'rule': {
         'relation': 'OR',
         'entries': [],
@@ -228,13 +228,14 @@ const newDocEntryFactory: { [key: string]: Function } = {
       'id': generateUUID2(),
       'name': 'New Rate Limit Rule',
       'global': false,
+      'active': false,
       'description': 'New Rate Limit Rule Description and Remarks',
       'timeframe': 60,
       'tags': [],
       'thresholds': [
         {
           'limit': 5,
-          'action': 'monitor',
+          'action': 'action-rate-limit-block',
         },
       ],
       'include': ['all'],
@@ -247,7 +248,7 @@ const newDocEntryFactory: { [key: string]: Function } = {
           'attrs': 'securitypolicyentryid',
         },
         {
-          'attrs': 'curiesession',
+          'attrs': 'session',
         },
       ],
       'pairwith': {
@@ -281,12 +282,12 @@ const newDocEntryFactory: { [key: string]: Function } = {
     }
   },
 
-  'cloud-functions'(): CloudFunction {
+  'cloud-functions'(): EdgeFunction {
     return {
       'id': generateUUID2(),
-      'name': 'New Cloud Function',
-      'description': 'New Cloud Function Description and Remarks',
-      'phase': 'request1',
+      'name': 'New Edge Function',
+      'description': 'New Edge Function Description and Remarks',
+      'phase': 'request',
       'code': `-- begin custom code
         --custom response header
         ngx.header['foo'] = 'bar'`,
@@ -390,11 +391,11 @@ const newOperationEntryFactory: { [key: string]: Function } = {
     }
   },
 
-  'proxy-templates'(): ProxyTemplate {
+  'proxy-templates'(): ConfigTemplate {
     return {
       'id': generateUUID2(),
-      'name': 'New Proxy Template ' + generateUUID2(), // TODO: Remove this random uuid once names are no longer unique
-      'description': 'New Proxy Template Description and Remarks',
+      'name': 'New Config Template ' + generateUUID2(), // TODO: Remove this random uuid once names are no longer unique
+      'description': 'New Config Template Description and Remarks',
       'acao_header': false,
       'xff_header_name': 'X-Forwarded-For',
       'post_private_args': '(cc_number|password)',

--- a/src/assets/__tests__/DatasetsUtils.spec.ts
+++ b/src/assets/__tests__/DatasetsUtils.spec.ts
@@ -102,7 +102,7 @@ describe('RequestsUtils.ts', () => {
       expect(document['thresholds'][0]['limit']).toEqual(5)
       expect(document['timeframe']).toEqual(60)
       expect(document['key']).toEqual([{'attrs': 'securitypolicyid'},
-        {'attrs': 'securitypolicyentryid'}, {'attrs': 'curiesession'}])
+        {'attrs': 'securitypolicyentryid'}, {'attrs': 'session'}])
       expect(document['thresholds'][0]['action']).toEqual('monitor')
       expect(document['pairwith']).toEqual({'self': 'self'})
       expect(document['exclude']).toEqual([])

--- a/src/components/GitHistory.vue
+++ b/src/components/GitHistory.vue
@@ -89,7 +89,9 @@
             </tbody>
           </table>
         </div>
-        <span class="is-family-monospace has-text-grey-lighter">{{ apiRoot }}/{{ apiVersion }}/{{ apiPath }}</span>
+        <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">
+          {{ apiRoot }}/{{ apiVersion }}/{{ apiPath }}
+        </span>
       </div>
     </div>
   </div>

--- a/src/components/LimitOption.vue
+++ b/src/components/LimitOption.vue
@@ -99,8 +99,7 @@ export const limitAttributes = {
   'company': 'Company',
   'country': 'Country',
   'authority': 'Authority',
-  'curiesession': 'Curie Session',
-  'curiesession_ids': 'Curie Session IDs',
+  'session': 'Session ID',
   'securitypolicyid': 'Security Policy ID',
   'securitypolicyentryid': 'Path Matching ID',
 }

--- a/src/components/RbzTable.vue
+++ b/src/components/RbzTable.vue
@@ -6,7 +6,7 @@
       <thead>
       <tr class="header-row"
           v-if="tableTitle">
-        <th :colspan="columns.length"
+        <th :colspan="totalColumns"
             class="has-text-centered table-title">
           {{ tableTitle }}
         </th>
@@ -33,7 +33,7 @@
         </th>
         <th class="column-header width-45px is-relative has-text-centered"
             v-if="showMenuColumn">
-          <div class="dropdown is-block"
+          <div class="dropdown is-block is-right"
                :class="{'is-active': menuVisible}">
             <div class="dropdown-trigger">
               <button class="button is-size-7 menu-toggle-button is-block"
@@ -72,7 +72,7 @@
                     <i class="fas fa-plus"></i>
                   </span>
                   <span>
-                    Add
+                    New
                   </span>
                 </button>
               </div>
@@ -103,6 +103,8 @@
       <tbody>
       <tr v-for="row in slicedDataArrayDisplay"
           :key="row.id"
+          @click="rowClickable && rowClicked(row.id)"
+          :class="{'is-clickable': rowClickable}"
           class="data-row">
         <td v-for="(col, index) in columns"
             :key="index"
@@ -136,7 +138,7 @@
         </td>
       </tr>
       <tr v-if="!slicedDataArrayDisplay?.length">
-        <td :colspan="columns.length"
+        <td :colspan="totalColumns"
             class="has-text-centered table-no-data-message">
           <div v-if="loading">
             <button class="button is-outlined is-text is-small is-loading document-loading">
@@ -144,13 +146,13 @@
             </button>
           </div>
           <div v-else>
-            No results found
+            No data found
           </div>
         </td>
       </tr>
       <tr v-if="totalPages > 1 && !useScroll"
           class="pagination-row">
-        <td :colspan="columns.length + 1">
+        <td :colspan="totalColumns">
           <div class="pagination is-small">
             <button class="pagination-previous"
                     @click="prevPage"
@@ -185,6 +187,7 @@ export default defineComponent({
     showMenuColumn: Boolean,
     showFilterButton: Boolean,
     showNewButton: Boolean,
+    rowClickable: Boolean,
     showRowButton: Boolean,
     rowButtonTitle: String,
     rowButtonIcon: String,
@@ -215,6 +218,7 @@ export default defineComponent({
             this.sortDirection = this.defaultSortColumnDirection
           }
           this.filter = {}
+          this.currentPage = 1
         }
       },
       immediate: true,
@@ -240,10 +244,10 @@ export default defineComponent({
       currentPage: 1,
     }
   },
-  emits: ['new-button-clicked', 'row-button-clicked'],
+  emits: ['new-button-clicked', 'row-button-clicked', 'row-clicked'],
   computed: {
     dataArrayDisplay() {
-      if (!this.data?.length) {
+      if (!this.data?.length || !Array.isArray(this.data)) {
         return []
       }
       const sortModifier = this.sortDirection === 'asc' ? 1 : -1
@@ -310,8 +314,13 @@ export default defineComponent({
       return this.dataArrayDisplay.slice(sliceStart, sliceEnd)
     },
 
-    totalPages() {
+    totalPages(): number {
       return Math.ceil(this.dataArrayDisplay.length / this.rowsPerPage) || 1
+    },
+
+    totalColumns(): number {
+      const extraColumns = this.showMenuColumn ? 1 : 0
+      return this.columns.length + extraColumns
     },
   },
   methods: {
@@ -321,6 +330,10 @@ export default defineComponent({
 
     rowButtonClicked(id: string) {
       this.$emit('row-button-clicked', id)
+    },
+
+    rowClicked(id: string) {
+      this.$emit('row-clicked', id)
     },
 
     sortColumn(column: ColumnOptions) {
@@ -439,6 +452,10 @@ export default defineComponent({
 .rbz-table .menu-toggle-button {
   background: transparent;
   border-color: transparent;
+}
+
+.rbz-table .dropdown-menu {
+  min-width: 0;
 }
 
 .rbz-table .menu-toggle-button:focus {

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -63,6 +63,7 @@ import _ from 'lodash'
 import {Branch} from '@/types'
 import Utils from '@/assets/Utils'
 import RequestsUtils from '@/assets/RequestsUtils'
+import packageJson from '../../package.json'
 
 export default defineComponent({
   name: 'SideMenu',
@@ -71,8 +72,12 @@ export default defineComponent({
     const kibanaURL = `${location.protocol}//${location.hostname}:5601/app/discover`
     const grafanaURL = `${location.protocol}//${location.hostname}:30300/`
     const prometheusURL = `${location.protocol}//${location.hostname}:9090/`
+    const splitVersion = packageJson.version.split('.')
+    const docsVersion = `${splitVersion[0]}.${splitVersion[1]}`
 
     return {
+      docsVersion: docsVersion,
+
       // Branches / Commits counters
       mdiSourceBranchPath: mdiSourceBranch,
       mdiSourceCommitPath: mdiSourceCommit,
@@ -128,8 +133,18 @@ export default defineComponent({
           title: 'Dashboard',
         },
         {
-          href: this.defaultGrafanaURL,
+          href: this.kibanaURL,
+          title: 'Kibana',
+          external: true,
+        },
+        {
+          href: this.grafanaURL,
           title: 'Grafana',
+          external: true,
+        },
+        {
+          href: this.prometheusURL,
+          title: 'Prometheus',
           external: true,
         },
         // {
@@ -192,27 +207,27 @@ export default defineComponent({
           href: `/${this.selectedBranch}/mobile-sdks`,
           title: 'Mobile SDKs',
         },
-        // ################
-        // Cloud Operations
-        // ################
+        // ##############
+        // Proxy Settings
+        // ##############
         {
-          header: 'Cloud Operations',
+          header: 'Proxy Settings',
         },
         {
-          href: `/${this.selectedBranch}/web-proxy`,
-          title: 'Web Proxy',
+          href: `/${this.selectedBranch}/server-groups`,
+          title: 'Server Groups',
         },
         {
           href: `/${this.selectedBranch}/routing-profiles`,
           title: 'Routing Profiles',
         },
         {
-          href: `/${this.selectedBranch}/proxy-templates`,
-          title: 'Proxy Templates',
+          href: `/${this.selectedBranch}/config-templates`,
+          title: 'Config Templates',
         },
         {
           href: `/${this.selectedBranch}/cloud-functions`,
-          title: 'Cloud Functions',
+          title: 'Edge Functions',
         },
         {
           href: `/${this.selectedBranch}/backend-services`,
@@ -255,13 +270,13 @@ export default defineComponent({
           title: 'Curiebook',
           external: true,
         },
-        // {
-        //   href: 'https://',
-        //   title: 'Reblazebook',
-        //   external: true,
-        // },
         {
-          href: this.defaultSwaggerURL,
+          href: `https://gb.docs.reblaze.com/v/v${this.docsVersion}`,
+          title: 'Reblazebook',
+          external: true,
+        },
+        {
+          href: this.swaggerURL,
           title: 'API',
           external: true,
         },

--- a/src/components/__tests__/EntriesRelationList.spec.ts
+++ b/src/components/__tests__/EntriesRelationList.spec.ts
@@ -3,15 +3,15 @@ import EntriesRelationList from '@/components/EntriesRelationList.vue'
 import {afterEach, beforeEach, describe, expect, jest, test} from '@jest/globals'
 import {DOMWrapper, mount, VueWrapper} from '@vue/test-utils'
 import _ from 'lodash'
-import {GlobalFilter, GlobalFilterSection, Rule} from '@/types'
+import {GlobalFilter, Rule} from '@/types'
 import {nextTick} from 'vue'
 
 
 describe('EntriesRelationList.vue', () => {
   let wrapper: VueWrapper
-  let ruleData: GlobalFilter['rule']
-  let entryData1: GlobalFilterSection
-  let entryData2: GlobalFilterSection
+  let ruleData: any
+  let entryData1: any
+  let entryData2: any
   beforeEach(() => {
     entryData1 = {
       relation: 'OR',
@@ -46,7 +46,7 @@ describe('EntriesRelationList.vue', () => {
         entryData2,
       ],
     }
-    const onUpdate = async (rule: GlobalFilter['rule']) => {
+    const onUpdate = async (rule: any) => {
       await wrapper.setProps({rule})
     }
     wrapper = mount(EntriesRelationList, {
@@ -220,7 +220,7 @@ describe('EntriesRelationList.vue', () => {
           entryData1,
         ],
       }
-      const onUpdate = (rule: GlobalFilter['rule']) => {
+      const onUpdate = (rule: any) => {
         wrapper.setProps({rule})
       }
       wrapper = mount(EntriesRelationList, {
@@ -724,7 +724,7 @@ describe('EntriesRelationList.vue', () => {
       expect(wrapper.vm.rule.entries[0].entries.length).toEqual(1)
     })
     test('should remove section if no entries left', async () => {
-      const entryData3: GlobalFilterSection = {
+      const entryData3: any = {
         relation: 'AND',
         entries: [
           [
@@ -795,7 +795,7 @@ describe('EntriesRelationList.vue', () => {
           entryData2,
         ],
       }
-      const onUpdate = async (rule: GlobalFilter['rule']) => {
+      const onUpdate = async (rule: any) => {
         await wrapper.setProps({rule})
       }
       wrapper = mount(EntriesRelationList, {

--- a/src/components/__tests__/RbzTable.spec.ts
+++ b/src/components/__tests__/RbzTable.spec.ts
@@ -48,7 +48,7 @@ describe('RbzTable.vue', () => {
         classes: 'width-80px',
       },
       {
-        title: 'Action',
+        title: 'Custom Response',
         fieldNames: ['action'],
         isSortable: true,
         classes: 'width-80px',
@@ -297,7 +297,7 @@ describe('RbzTable.vue', () => {
           classes: 'width-100px',
         },
         {
-          title: 'Action',
+          title: 'Custom Response',
           fieldNames: ['action'],
           isSortable: true,
           isSearchable: true,

--- a/src/doc-editors/ACLEditor.vue
+++ b/src/doc-editors/ACLEditor.vue
@@ -36,7 +36,7 @@
             </div>
             <div class="field">
               <label class="label is-small">
-                Action
+                Custom Response
               </label>
               <div class="control is-expanded">
                 <div class="select is-fullwidth is-small">
@@ -44,7 +44,7 @@
                           @change="emitDocUpdate"
                           data-qa="action-dropdown"
                           class="document-action-selection"
-                          title="Action">
+                          title="Custom Response">
                     <option v-for="customResponse in customResponseNames"
                             :value="customResponse[0]"
                             :key="customResponse[0]">
@@ -129,7 +129,7 @@
           </table>
         </div>
       </div>
-      <span class="is-family-monospace has-text-grey-lighter">{{ apiPath }}</span>
+      <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ apiPath }}</span>
     </div>
   </div>
 </template>

--- a/src/doc-editors/BackendServicesEditor.vue
+++ b/src/doc-editors/BackendServicesEditor.vue
@@ -10,20 +10,12 @@
                         @click="redirectToList()"
                         title="Return to list"
                         data-qa="redirect-to-list">
-                        <span class="icon is-small">
-                          <i class="fas fa-arrow-left"></i>
-                        </span>
-                </button>
-              </p>
-              <p class="control">
-                <button class="button is-small download-doc-button"
-                        :class="{'is-loading':isDownloadLoading}"
-                        @click="downloadDoc()"
-                        title="Download document"
-                        data-qa="download-document">
-                        <span class="icon is-small">
-                          <i class="fas fa-download"></i>
-                        </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-arrow-left"></i>
+                  </span>
+                  <span>
+                    Return To List
+                  </span>
                 </button>
               </p>
             </div>
@@ -31,14 +23,31 @@
           <div class="column">
             <div class="field is-grouped is-pulled-right">
               <p class="control">
+                <button class="button is-small download-doc-button"
+                        :class="{'is-loading':isDownloadLoading}"
+                        @click="downloadDoc()"
+                        title="Download document"
+                        data-qa="download-document">
+                  <span class="icon is-small">
+                    <i class="fas fa-download"></i>
+                  </span>
+                  <span>
+                    Download
+                  </span>
+                </button>
+              </p>
+              <p class="control">
                 <button class="button is-small save-document-button"
                         :class="{'is-loading': isSaveLoading}"
                         title="Save changes"
                         data-qa="save-changes"
                         @click="saveChanges()">
-                      <span class="icon is-small">
-                        <i class="fas fa-save"></i>
-                      </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-save"></i>
+                  </span>
+                  <span>
+                    Save
+                  </span>
                 </button>
               </p>
               <p class="control">
@@ -48,9 +57,12 @@
                         :class="{'is-loading': isDeleteLoading}"
                         :disabled="selectedBackendService?.id === '__default__'"
                         @click="deleteDoc()">
-                      <span class="icon is-small">
-                        <i class="fas fa-trash"></i>
-                      </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-trash"></i>
+                  </span>
+                  <span>
+                    Delete
+                  </span>
                 </button>
               </p>
             </div>
@@ -257,7 +269,7 @@
               </table>
             </div>
           </div>
-          <span class="is-family-monospace has-text-grey-lighter">{{ documentAPIPath }}</span>
+          <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ documentAPIPath }}</span>
         </div>
       </div>
     </div>

--- a/src/doc-editors/ConfigTemplatesEditor.vue
+++ b/src/doc-editors/ConfigTemplatesEditor.vue
@@ -10,20 +10,12 @@
                         @click="redirectToList()"
                         title="Return to list"
                         data-qa="redirect-to-list">
-                        <span class="icon is-small">
-                          <i class="fas fa-arrow-left"></i>
-                        </span>
-                </button>
-              </p>
-              <p class="control">
-                <button class="button is-small download-doc-button"
-                        :class="{'is-loading':isDownloadLoading}"
-                        @click="downloadDoc()"
-                        title="Download document"
-                        data-qa="download-document">
-                        <span class="icon is-small">
-                          <i class="fas fa-download"></i>
-                        </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-arrow-left"></i>
+                  </span>
+                  <span>
+                    Return To List
+                  </span>
                 </button>
               </p>
             </div>
@@ -31,14 +23,31 @@
           <div class="column">
             <div class="field is-grouped is-pulled-right">
               <p class="control">
+                <button class="button is-small download-doc-button"
+                        :class="{'is-loading':isDownloadLoading}"
+                        @click="downloadDoc()"
+                        title="Download document"
+                        data-qa="download-document">
+                  <span class="icon is-small">
+                    <i class="fas fa-download"></i>
+                  </span>
+                  <span>
+                    Download
+                  </span>
+                </button>
+              </p>
+              <p class="control">
                 <button class="button is-small save-document-button"
                         :class="{'is-loading': isSaveLoading}"
                         title="Save changes"
                         data-qa="save-changes"
                         @click="saveChanges()">
-                      <span class="icon is-small">
-                        <i class="fas fa-save"></i>
-                      </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-save"></i>
+                  </span>
+                  <span>
+                    Save
+                  </span>
                 </button>
               </p>
               <p class="control">
@@ -46,11 +55,14 @@
                         title="Delete document"
                         data-qa="delete-document"
                         :class="{'is-loading': isDeleteLoading}"
-                        :disabled="selectedProxyTemplate?.id === '__default__'"
+                        :disabled="selectedConfigTemplate?.id === '__default__'"
                         @click="deleteDoc()">
-                      <span class="icon is-small">
-                        <i class="fas fa-trash"></i>
-                      </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-trash"></i>
+                  </span>
+                  <span>
+                    Delete
+                  </span>
                 </button>
               </p>
             </div>
@@ -62,7 +74,7 @@
     <div class="card">
       <div class="card-content">
         <div class="content"
-             v-if="selectedProxyTemplate">
+             v-if="selectedConfigTemplate">
           <div class="columns">
             <div class="column is-4">
               <div class="field">
@@ -70,14 +82,14 @@
                   Name
                   <span class="has-text-grey is-pulled-right document-id"
                         title="Rule id">
-                      {{ selectedProxyTemplate.id }}
+                      {{ selectedConfigTemplate.id }}
                     </span>
                 </label>
                 <div class="control">
                   <input class="input is-small document-name"
                          title="Document name"
                          placeholder="Document name"
-                         v-model="selectedProxyTemplate.name"/>
+                         v-model="selectedConfigTemplate.name"/>
                 </div>
               </div>
               <div class="field">
@@ -87,7 +99,7 @@
                       <textarea class="is-small textarea document-description"
                                 data-qa="description-input"
                                 title="Document description"
-                                v-model="selectedProxyTemplate.description"
+                                v-model="selectedConfigTemplate.description"
                                 rows="5">
                       </textarea>
                   </div>
@@ -123,7 +135,7 @@
                         <input class="input is-small document-ip-header-name"
                                title="Client IP header name"
                                placeholder="Client IP header name"
-                               v-model="selectedProxyTemplate.xff_header_name">
+                               v-model="selectedConfigTemplate.xff_header_name">
                       </div>
                       <div class="help">
                         The header name which Reblaze will use to extract the client's IP address
@@ -137,7 +149,7 @@
                         <input class="input is-small document-limit-req-rate"
                                title="Requests per second per IP address"
                                placeholder="Requests per second per IP address"
-                               v-model="selectedProxyTemplate.limit_req_rate">
+                               v-model="selectedConfigTemplate.limit_req_rate">
                       </div>
                       <div class="help">
                         Static rate limiting for each IP address: the requests per second per IP address for this
@@ -155,7 +167,7 @@
                         <input class="input is-small document-client-body-timeout"
                                title="Client body timeout"
                                placeholder="Client body timeout"
-                               v-model="selectedProxyTemplate.client_body_timeout">
+                               v-model="selectedConfigTemplate.client_body_timeout">
                       </div>
                       <div class="help">
                         Defines a timeout for reading client request body, for a period between two successive read
@@ -174,7 +186,7 @@
                         <input class="input is-small document-client-header-timeout"
                                title="Client header timeout"
                                placeholder="Client header timeout"
-                               v-model="selectedProxyTemplate.client_header_timeout">
+                               v-model="selectedConfigTemplate.client_header_timeout">
                       </div>
                       <div class="help">
                         Defines a timeout for reading client request header. If a client does not transmit the entire
@@ -196,7 +208,7 @@
                         <input class="input is-small document-client-max-body-size"
                                title="Client max body size"
                                placeholder="Client max body size"
-                               v-model="selectedProxyTemplate.client_max_body_size">
+                               v-model="selectedConfigTemplate.client_max_body_size">
                       </div>
                       <div class="help">
                         Sets the maximum allowed size of the client request body, based on “Content-Length” request
@@ -216,7 +228,7 @@
                         <input class="input is-small document-limit-req-burst"
                                title="Burst of requests per second per IP address"
                                placeholder="Burst of requests per second per IP address"
-                               v-model="selectedProxyTemplate.limit_req_burst">
+                               v-model="selectedConfigTemplate.limit_req_burst">
                       </div>
                       <div class="help">
                         The burst parameter defines how many requests a client can make in excess of the rate
@@ -236,7 +248,7 @@
                         <input class="input is-small document-keepalive-timeout"
                                title="Keepalive timeout"
                                placeholder="Keepalive timeout"
-                               v-model="selectedProxyTemplate.keepalive_timeout">
+                               v-model="selectedConfigTemplate.keepalive_timeout">
                       </div>
                       <div class="help">
                         Defines a timeout during which a keep-alive client connection will stay open on the server
@@ -256,7 +268,7 @@
                         <input class="input is-small document-send-timeout"
                                title="Send timeout"
                                placeholder="Send timeout"
-                               v-model="selectedProxyTemplate.send_timeout">
+                               v-model="selectedConfigTemplate.send_timeout">
                       </div>
                       <div class="help">
                         Defines a timeout for transmitting a response to the client between two successive write
@@ -301,7 +313,7 @@
                         <input class="input is-small document-proxy-connect-timeout"
                                title="Proxy connect timeout"
                                placeholder="Proxy connect timeout"
-                               v-model="selectedProxyTemplate.proxy_connect_timeout">
+                               v-model="selectedConfigTemplate.proxy_connect_timeout">
                       </div>
                       <div class="help">
                         Defines a timeout for establishing a connection with a proxied server. It should be noted that
@@ -320,7 +332,7 @@
                         <input class="input is-small document-proxy-sen-timeout"
                                title="Proxy send timeout"
                                placeholder="Proxy send timeout"
-                               v-model="selectedProxyTemplate.proxy_send_timeout">
+                               v-model="selectedConfigTemplate.proxy_send_timeout">
                       </div>
                       <div class="help">
                         Sets a timeout for transmitting a request to the proxied server. The timeout is set only
@@ -340,7 +352,7 @@
                         <input class="input is-small document-proxy-read-timeout"
                                title="Proxy read timeout"
                                placeholder="Proxy read timeout"
-                               v-model="selectedProxyTemplate.proxy_read_timeout">
+                               v-model="selectedConfigTemplate.proxy_read_timeout">
                       </div>
                       <div class="help">
                         Defines a timeout for reading a response from the proxied server. The timeout is set only
@@ -362,7 +374,7 @@
                         <input class="input is-small document-upstream-host"
                                title="Backend service host header"
                                placeholder="Backend service host header"
-                               v-model="selectedProxyTemplate.upstream_host">
+                               v-model="selectedConfigTemplate.upstream_host">
                       </div>
                       <div class="help">
                         The Host header Reblaze will present to the backend service.<br/>Setting value to $host means
@@ -377,7 +389,7 @@
                         <input class="input is-small document-real-ip-header-name"
                                title="Real IP header name"
                                placeholder="Real IP header name"
-                               v-model="selectedProxyTemplate.xrealip_header_name">
+                               v-model="selectedConfigTemplate.xrealip_header_name">
                       </div>
                       <div class="help">
                         The Host header Reblaze will present to the backend service.<br/>X-Real-IP is the default
@@ -389,7 +401,7 @@
               </div>
             </div>
           </div>
-          <span class="is-family-monospace has-text-grey-lighter">{{ documentAPIPath }}</span>
+          <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ documentAPIPath }}</span>
         </div>
       </div>
     </div>
@@ -397,7 +409,7 @@
 </template>
 <script lang="ts">
 import RequestsUtils from '@/assets/RequestsUtils'
-import {ProxyTemplate} from '@/types'
+import {ConfigTemplate} from '@/types'
 import Utils from '@/assets/Utils'
 import {defineComponent} from 'vue'
 import DatasetsUtils from '@/assets/DatasetsUtils'
@@ -405,11 +417,11 @@ import {mapStores} from 'pinia'
 import {useBranchesStore} from '@/stores/BranchesStore'
 
 export default defineComponent({
-  name: 'ProxyTemplateEditor',
+  name: 'ConfigTemplateEditor',
   data() {
     return {
       titles: DatasetsUtils.titles,
-      selectedProxyTemplate: null as ProxyTemplate,
+      selectedConfigTemplate: null as ConfigTemplate,
       docIdFromRoute: '',
 
       // Collapsible cards
@@ -429,7 +441,7 @@ export default defineComponent({
   watch: {
     selectedBranch: {
       handler: function(val, oldVal) {
-        if ((this.$route.name as string).includes('ProxyTemplates/config') && val && val !== oldVal) {
+        if ((this.$route.name as string).includes('ConfigTemplates/config') && val && val !== oldVal) {
           this.setSelectedDataFromRouteParams()
         }
       },
@@ -439,7 +451,8 @@ export default defineComponent({
   computed: {
     documentAPIPath(): string {
       const apiPrefix = `${this.apiRoot}/${this.apiVersion}`
-      return `${apiPrefix}/reblaze/configs/${this.selectedBranch}/d/proxy-templates/e/${this.selectedProxyTemplate.id}/`
+      const apiPath = `configs/${this.selectedBranch}/d/proxy-templates/e/${this.selectedConfigTemplate.id}/`
+      return `${apiPrefix}/reblaze/${apiPath}`
     },
 
     selectedBranch(): string {
@@ -452,11 +465,11 @@ export default defineComponent({
     async setSelectedDataFromRouteParams() {
       this.setLoadingDocStatus(true)
       this.docIdFromRoute = this.$route.params?.doc_id?.toString()
-      await this.loadProxyTemplate()
+      await this.loadConfigTemplate()
     },
 
     redirectToList() {
-      this.$router.push(`/${this.selectedBranch}/proxy-templates/list`)
+      this.$router.push(`/${this.selectedBranch}/config-templates/list`)
     },
 
     setLoadingDocStatus(isLoading: boolean) {
@@ -470,23 +483,23 @@ export default defineComponent({
     async switchBranch() {
       this.setLoadingDocStatus(true)
       Utils.toast(`Switched to branch '${this.selectedBranch}'.`, 'is-info')
-      await this.loadProxyTemplate()
+      await this.loadConfigTemplate()
       this.setLoadingDocStatus(false)
     },
 
     downloadDoc() {
       if (!this.isDownloadLoading) {
-        Utils.downloadFile('proxy-template', 'json', this.selectedProxyTemplate)
+        Utils.downloadFile(this.titles['proxy-templates-singular'], 'json', this.selectedConfigTemplate)
       }
     },
 
     async deleteDoc() {
       this.setLoadingDocStatus(true)
       this.isDeleteLoading = true
-      const proxyTemplateText = this.titles['proxy-templates-singular']
-      const url = `configs/${this.selectedBranch}/d/proxy-templates/e/${this.selectedProxyTemplate.id}/`
-      const successMessage = `The ${proxyTemplateText} was deleted.`
-      const failureMessage = `Failed while attempting to delete the ${proxyTemplateText}.`
+      const configTemplateText = this.titles['proxy-templates-singular']
+      const url = `configs/${this.selectedBranch}/d/proxy-templates/e/${this.selectedConfigTemplate.id}/`
+      const successMessage = `The ${configTemplateText} was deleted.`
+      const failureMessage = `Failed while attempting to delete the ${configTemplateText}.`
       await RequestsUtils.sendReblazeRequest({
         methodName: 'DELETE',
         url: url,
@@ -501,27 +514,27 @@ export default defineComponent({
     async saveChanges() {
       this.isSaveLoading = true
       const methodName = 'PUT'
-      const url = `configs/${this.selectedBranch}/d/proxy-templates/e/${this.selectedProxyTemplate.id}/`
-      const data = this.selectedProxyTemplate
-      const proxyTemplateText = this.titles['proxy-templates-singular']
-      const successMessage = `Changes to the ${proxyTemplateText} were saved.`
-      const failureMessage = `Failed while attempting to save the changes to the ${proxyTemplateText}.`
+      const url = `configs/${this.selectedBranch}/d/proxy-templates/e/${this.selectedConfigTemplate.id}/`
+      const data = this.selectedConfigTemplate
+      const configTemplateText = this.titles['proxy-templates-singular']
+      const successMessage = `Changes to the ${configTemplateText} were saved.`
+      const failureMessage = `Failed while attempting to save the changes to the ${configTemplateText}.`
       await RequestsUtils.sendReblazeRequest({methodName, url, data, successMessage, failureMessage})
       this.isSaveLoading = false
     },
 
-    async loadProxyTemplate() {
+    async loadConfigTemplate() {
       this.isDownloadLoading = true
       const response = await RequestsUtils.sendReblazeRequest({
         methodName: 'GET',
         url: `configs/${this.selectedBranch}/d/proxy-templates/e/${this.docIdFromRoute}`,
         onFail: () => {
-          console.log('Error while attempting to load the Proxy Template')
-          this.selectedProxyTemplate = null
+          console.log(`Error while attempting to load the ${this.titles['proxy-template-singular']}`)
+          this.selectedConfigTemplate = null
           this.isDownloadLoading = false
         },
       })
-      this.selectedProxyTemplate = response?.data || {}
+      this.selectedConfigTemplate = response?.data || {}
       this.isDownloadLoading = false
     },
   },

--- a/src/doc-editors/ContentFilterProfilesEditor.vue
+++ b/src/doc-editors/ContentFilterProfilesEditor.vue
@@ -28,9 +28,9 @@
                    title="Masking seed"
                    data-qa="waf-masking"
                    placeholder="Masking seed"
-                   type="password"
-                   @change="emitDocUpdate"
-                   v-model="localDoc.masking_seed"/>
+                   @focus="maskingSeedHidden = false"
+                   @blur="maskingSeedHidden = true"
+                   v-model="maskingSeed"/>
           </div>
         </div>
 
@@ -48,7 +48,7 @@
         </div>
         <div class="field">
           <label class="label is-small">
-            Action
+            Custom Response
           </label>
           <div class="control is-expanded">
             <div class="select is-fullwidth is-small">
@@ -56,7 +56,7 @@
                       @change="emitDocUpdate"
                       data-qa="action-dropdown"
                       class="document-action-selection"
-                      title="Action">
+                      title="Custom Response">
                 <option v-for="customResponse in customResponseNames"
                         :value="customResponse[0]"
                         :key="customResponse[0]">
@@ -631,7 +631,7 @@
         </div>
       </div>
     </div>
-    <span class="is-family-monospace has-text-grey-lighter">{{ apiPath }}</span>
+    <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ apiPath }}</span>
   </div>
 </template>
 
@@ -751,6 +751,7 @@ export default defineComponent({
         },
       ],
       customResponseNames: [] as [CustomResponse['id'], CustomResponse['name']][],
+      maskingSeedHidden: true,
     }
   },
 
@@ -783,6 +784,20 @@ export default defineComponent({
         return 'Matching Value cannot be empty if Mask is unchecked & Ignore Tags is empty'
       }
       return 'Add new parameter'
+    },
+
+    maskingSeed: {
+      get: function(): string {
+        if (this.maskingSeedHidden) {
+          return '•••••'
+        } else {
+          return this.localDoc.masking_seed
+        }
+      },
+      set: function(value: string): void {
+        this.localDoc.masking_seed = value
+        this.emitDocUpdate()
+      },
     },
 
     selectedDocTags: {

--- a/src/doc-editors/CustomResponsesEditor.vue
+++ b/src/doc-editors/CustomResponsesEditor.vue
@@ -131,7 +131,7 @@
           </div>
         </div>
       </div>
-      <span class="is-family-monospace has-text-grey-lighter">{{ apiPath }}</span>
+      <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ apiPath }}</span>
     </div>
   </div>
 </template>

--- a/src/doc-editors/DynamicRulesEditor.vue
+++ b/src/doc-editors/DynamicRulesEditor.vue
@@ -95,7 +95,7 @@
           </div>
           <div class="field">
             <label class="label is-small">
-              Action
+              Custom Response
             </label>
             <div class="control is-expanded">
               <div class="select is-fullwidth is-small">
@@ -103,7 +103,7 @@
                         @change="emitDocUpdate"
                         data-qa="action-dropdown"
                         class="document-action-selection"
-                        title="Action">
+                        title="Custom Response">
                   <option v-for="customResponse in customResponseNames"
                           :value="customResponse[0]"
                           :key="customResponse[0]">
@@ -201,7 +201,7 @@
         </div>
       </div>
     </div>
-    <span class="is-family-monospace has-text-grey-lighter">{{ apiPath }}</span>
+    <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ apiPath }}</span>
   </div>
 </template>
 <script lang="ts">

--- a/src/doc-editors/EdgeFunctionsEditor.vue
+++ b/src/doc-editors/EdgeFunctionsEditor.vue
@@ -8,12 +8,12 @@
               Name
               <span class="has-text-grey is-pulled-right document-id"
                     title="Document id">
-                    {{ localDoc.id }}
-                  </span>
+                {{ localDoc.id }}
+              </span>
             </label>
             <div class="control">
               <input class="input is-small document-name"
-                     data-qa="cloud-functions-name-input"
+                     data-qa="edge-functions-name-input"
                      type="text"
                      title="Document name"
                      placeholder="Document name"
@@ -55,7 +55,7 @@
         <div class="column is-8">
           <div class="field">
             <label class="label is-small">Code</label>
-            <textarea class="is-small textarea is-family-monospace cloud-functions-code"
+            <textarea class="is-small textarea edge-functions-code"
                       data-qa="code-input"
                       title="code"
                       v-model="localDoc.code"
@@ -66,34 +66,34 @@
         </div>
       </div>
     </div>
-    <span class="is-family-monospace has-text-grey-lighter">{{ apiPath }}</span>
+    <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ apiPath }}</span>
   </div>
 </template>
 
 <script lang="ts">
 import _ from 'lodash'
 import {defineComponent, PropType} from 'vue'
-import {CloudFunction, CloudFunctionsPhaseType} from '@/types'
+import {EdgeFunction, EdgeFunctionsPhaseType} from '@/types'
 import DatasetsUtils from '@/assets/DatasetsUtils'
 
 
 export default defineComponent({
-  name: 'CloudFunctionsEditor',
+  name: 'EdgeFunctionsEditor',
   props: {
-    selectedDoc: Object as PropType<CloudFunction>,
+    selectedDoc: Object as PropType<EdgeFunction>,
     selectedBranch: String,
     apiPath: String,
     docs: Array,
   },
   data() {
     return {
-      cloudPhases: ['request1', 'response0'] as CloudFunctionsPhaseType[],
+      cloudPhases: ['request', 'response'] as EdgeFunctionsPhaseType[],
       titles: DatasetsUtils.titles,
     }
   },
   computed: {
-    localDoc(): CloudFunction {
-      return _.cloneDeep(this.selectedDoc as CloudFunction)
+    localDoc(): EdgeFunction {
+      return _.cloneDeep(this.selectedDoc as EdgeFunction)
     },
   },
   emits: ['update:selectedDoc'],

--- a/src/doc-editors/FlowControlPoliciesEditor.vue
+++ b/src/doc-editors/FlowControlPoliciesEditor.vue
@@ -348,7 +348,7 @@
           </div>
         </div>
       </div>
-      <span class="is-family-monospace has-text-grey-lighter">{{ apiPath }}</span>
+      <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ apiPath }}</span>
     </div>
   </div>
 </template>

--- a/src/doc-editors/MobileSDKsEditor.vue
+++ b/src/doc-editors/MobileSDKsEditor.vue
@@ -11,20 +11,12 @@
                         @click="redirectToList()"
                         title="Return to list"
                         data-qa="redirect-to-list">
-                        <span class="icon is-small">
-                          <i class="fas fa-arrow-left"></i>
-                        </span>
-                </button>
-              </p>
-              <p class="control">
-                <button class="button is-small download-doc-button"
-                        :class="{'is-loading':isDownloadLoading}"
-                        @click="downloadDoc()"
-                        title="Download document"
-                        data-qa="download-document">
-                    <span class="icon is-small">
-                      <i class="fas fa-download"></i>
-                    </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-arrow-left"></i>
+                  </span>
+                  <span>
+                    Return To List
+                  </span>
                 </button>
               </p>
             </div>
@@ -32,14 +24,31 @@
           <div class="column">
             <div class="field is-grouped is-pulled-right">
               <p class="control">
+                <button class="button is-small download-doc-button"
+                        :class="{'is-loading':isDownloadLoading}"
+                        @click="downloadDoc()"
+                        title="Download document"
+                        data-qa="download-document">
+                  <span class="icon is-small">
+                    <i class="fas fa-download"></i>
+                  </span>
+                  <span>
+                    Download
+                  </span>
+                </button>
+              </p>
+              <p class="control">
                 <button class="button is-small save-document-button"
                         :class="{'is-loading': isSaveLoading}"
                         title="Save changes"
                         data-qa="save-changes"
                         @click="saveChanges()">
-                    <span class="icon is-small">
-                      <i class="fas fa-save"></i>
-                    </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-save"></i>
+                  </span>
+                  <span>
+                    Save
+                  </span>
                 </button>
               </p>
               <p class="control">
@@ -49,9 +58,12 @@
                         :class="{'is-loading': isDeleteLoading}"
                         :disabled="selectedMobileSDK?.id === '__default__'"
                         @click="deleteDoc()">
-                    <span class="icon is-small">
-                      <i class="fas fa-trash"></i>
-                    </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-trash"></i>
+                  </span>
+                  <span>
+                    Delete
+                  </span>
                 </button>
               </p>
             </div>
@@ -326,7 +338,7 @@
               </table>
             </div>
           </div>
-          <span class="is-family-monospace has-text-grey-lighter">{{ documentAPIPath }}</span>
+          <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ documentAPIPath }}</span>
         </div>
       </div>
     </div>

--- a/src/doc-editors/RateLimitRulesEditor.vue
+++ b/src/doc-editors/RateLimitRulesEditor.vue
@@ -23,6 +23,16 @@
           <div class="field">
             <label class="checkbox is-size-7">
               <input type="checkbox"
+                     data-qa="active-checkbox"
+                     class="document-active"
+                     @change="emitDocUpdate"
+                     v-model="localDoc.active">
+              Active
+            </label>
+          </div>
+          <div class="field">
+            <label class="checkbox is-size-7">
+              <input type="checkbox"
                      data-qa="global-checkbox"
                      class="document-global"
                      @change="emitDocUpdate"
@@ -140,7 +150,7 @@
               </div>
               <div class="field">
                 <label class="label is-small">
-                  Action
+                  Custom Response
                 </label>
                 <div class="control is-expanded">
                   <div class="select is-fullwidth is-small">
@@ -148,7 +158,7 @@
                             @change="emitDocUpdate"
                             data-qa="action-dropdown"
                             class="threshold-action-selection"
-                            title="Action">
+                            title="Custom Response">
                       <option v-for="customResponse in customResponseNames"
                               :value="customResponse[0]"
                               :key="customResponse[0]">

--- a/src/doc-editors/RoutingProfilesEditor.vue
+++ b/src/doc-editors/RoutingProfilesEditor.vue
@@ -10,20 +10,12 @@
                         @click="redirectToList()"
                         title="Return to list"
                         data-qa="redirect-to-list">
-                        <span class="icon is-small">
-                          <i class="fas fa-arrow-left"></i>
-                        </span>
-                </button>
-              </p>
-              <p class="control">
-                <button class="button is-small download-doc-button"
-                        :class="{'is-loading':isDownloadLoading}"
-                        @click="downloadDoc()"
-                        title="Download document"
-                        data-qa="download-document">
-                        <span class="icon is-small">
-                          <i class="fas fa-download"></i>
-                        </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-arrow-left"></i>
+                  </span>
+                  <span>
+                    Return To List
+                  </span>
                 </button>
               </p>
             </div>
@@ -31,14 +23,31 @@
           <div class="column">
             <div class="field is-grouped is-pulled-right">
               <p class="control">
+                <button class="button is-small download-doc-button"
+                        :class="{'is-loading':isDownloadLoading}"
+                        @click="downloadDoc()"
+                        title="Download document"
+                        data-qa="download-document">
+                  <span class="icon is-small">
+                    <i class="fas fa-download"></i>
+                  </span>
+                  <span>
+                    Download
+                  </span>
+                </button>
+              </p>
+              <p class="control">
                 <button class="button is-small save-document-button"
                         :class="{'is-loading': isSaveLoading}"
                         title="Save changes"
                         data-qa="save-changes"
                         @click="saveChanges()">
-                      <span class="icon is-small">
-                        <i class="fas fa-save"></i>
-                      </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-save"></i>
+                  </span>
+                  <span>
+                    Save
+                  </span>
                 </button>
               </p>
               <p class="control">
@@ -48,9 +57,12 @@
                         :class="{'is-loading': isDeleteLoading}"
                         :disabled="selectedRoutingProfile?.id === '__default__'"
                         @click="deleteDoc()">
-                      <span class="icon is-small">
-                        <i class="fas fa-trash"></i>
-                      </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-trash"></i>
+                  </span>
+                  <span>
+                    Delete
+                  </span>
                 </button>
               </p>
             </div>
@@ -105,7 +117,7 @@
                 <th class="is-size-7 width-50px"></th>
                 <th class="is-size-7 width-400px">Path</th>
                 <th class="is-size-7 width-150px">Backend Service</th>
-                <th class="is-size-7 width-150px">Cloud Functions</th>
+                <th class="is-size-7 width-150px">Edge Functions</th>
                 <th></th>
               </tr>
               </thead>
@@ -124,9 +136,9 @@
                 <td class="is-size-7 width-150px ellipsis entry-content-filter">
                   {{ backendServiceName(mapEntry.backend_id) }}
                 </td>
-                <td class="is-size-7 width-150px entry-cloud-functions-count"
-                    v-if="existingCloudFunctionIDs(mapEntry)">
-                  {{ existingCloudFunctionIDs(mapEntry).length }}
+                <td class="is-size-7 width-150px entry-edge-functions-count"
+                    v-if="existingEdgeFunctionIDs(mapEntry)">
+                  {{ existingEdgeFunctionIDs(mapEntry).length }}
                 </td>
                 <td class="is-size-7 width-70px"
                     :rowspan="mapEntryIndex === mapIndex ? '2' : '1'">
@@ -172,15 +184,15 @@
                             </div>
                             <hr/>
                             <p class="title is-6 has-text-grey">
-                              Cloud Functions
+                              Edge Functions
                             </p>
                             <div class="content">
                               <table class="table is-hoverable is-narrow is-fullwidth
-                                              current-entry-cloud-functions-table">
+                                              current-entry-edge-functions-table">
                                 <thead>
                                 <tr>
                                   <th class="is-size-7 width-250px">
-                                    Cloud Function Name
+                                    Edge Function Name
                                   </th>
                                   <th class="is-size-7 width-200px">
                                     Description
@@ -189,94 +201,94 @@
                                     Phase
                                   </th>
                                   <th class="has-text-centered is-size-7 width-60px">
-                                    <a v-if="cloudFunctions && mapEntry.cloud_functions &&
-                                             cloudFunctions.length > existingCloudFunctionIDs(mapEntry).length"
-                                       class="has-text-grey-dark is-small cloud-function-add-button"
-                                       data-qa="add-existing-cloud-function"
+                                    <a v-if="edgeFunctions && mapEntry.cloud_functions &&
+                                             edgeFunctions.length > existingEdgeFunctionIDs(mapEntry).length"
+                                       class="has-text-grey-dark is-small edge-function-add-button"
+                                       data-qa="add-existing-edge-function"
                                        title="Add new"
                                        tabindex="0"
-                                       @click="cloudFunctionNewEntryModeMapEntryId = mapIndex"
+                                       @click="edgeFunctionNewEntryModeMapEntryId = mapIndex"
                                        @keypress.space.prevent
-                                       @keypress.space="cloudFunctionNewEntryModeMapEntryId = mapIndex"
-                                       @keypress.enter="cloudFunctionNewEntryModeMapEntryId = mapIndex">
+                                       @keypress.space="edgeFunctionNewEntryModeMapEntryId = mapIndex"
+                                       @keypress.enter="edgeFunctionNewEntryModeMapEntryId = mapIndex">
                                       <span class="icon is-small"><i class="fas fa-plus"></i></span>
                                     </a>
                                   </th>
                                 </tr>
                                 </thead>
                                 <tbody>
-                                <template v-for="(cloudFunctionId, cloudFunctionIndex) in mapEntry.cloud_functions">
-                                  <tr v-if="cloudFunctionsDetails(cloudFunctionId)"
-                                      :key="cloudFunctionId"
-                                      class="cloud-function-row">
-                                    <td class="is-size-7 width-250px ellipsis cloud-function-name"
-                                        v-if="cloudFunctionsDetails(cloudFunctionId)"
-                                        :title="cloudFunctionsDetails(cloudFunctionId).name">
-                                      {{ cloudFunctionsDetails(cloudFunctionId).name }}
+                                <template v-for="(edgeFunctionId, edgeFunctionIndex) in mapEntry.cloud_functions">
+                                  <tr v-if="edgeFunctionsDetails(edgeFunctionId)"
+                                      :key="edgeFunctionId"
+                                      class="edge-function-row">
+                                    <td class="is-size-7 width-250px ellipsis edge-function-name"
+                                        v-if="edgeFunctionsDetails(edgeFunctionId)"
+                                        :title="edgeFunctionsDetails(edgeFunctionId).name">
+                                      {{ edgeFunctionsDetails(edgeFunctionId).name }}
                                     </td>
-                                    <td class="is-size-7 width-220px ellipsis cloud-function-description"
-                                        v-if="cloudFunctionsDetails(cloudFunctionId)"
-                                        :title="cloudFunctionsDetails(cloudFunctionId).description">
-                                      {{ cloudFunctionsDetails(cloudFunctionId).description }}
+                                    <td class="is-size-7 width-220px ellipsis edge-function-description"
+                                        v-if="edgeFunctionsDetails(edgeFunctionId)"
+                                        :title="edgeFunctionsDetails(edgeFunctionId).description">
+                                      {{ edgeFunctionsDetails(edgeFunctionId).description }}
                                     </td>
-                                    <td class="is-size-7 width-80px ellipsis cloud-function-timeframe"
-                                        v-if="cloudFunctionsDetails(cloudFunctionId)">
-                                      {{ cloudFunctionsDetails(cloudFunctionId).phase }}
+                                    <td class="is-size-7 width-80px ellipsis edge-function-timeframe"
+                                        v-if="edgeFunctionsDetails(edgeFunctionId)">
+                                      {{ edgeFunctionsDetails(edgeFunctionId).phase }}
                                     </td>
                                     <td class="has-text-centered is-size-7 width-60px">
-                                      <a class="is-small has-text-grey cloud-function-remove-button"
-                                         data-qa="remove-cloud-function-btn"
+                                      <a class="is-small has-text-grey edge-function-remove-button"
+                                         data-qa="remove-edge-function-btn"
                                          title="Remove entry"
                                          tabindex="0"
-                                         @click="removeCloudFunctionFromEntry(mapEntry, cloudFunctionIndex)"
+                                         @click="removeEdgeFunctionFromEntry(mapEntry, edgeFunctionIndex)"
                                          @keypress.space.prevent
-                                         @keypress.space="removeCloudFunctionFromEntry(mapEntry, cloudFunctionIndex)"
-                                         @keypress.enter="removeCloudFunctionFromEntry(mapEntry, cloudFunctionIndex)">
+                                         @keypress.space="removeEdgeFunctionFromEntry(mapEntry, edgeFunctionIndex)"
+                                         @keypress.enter="removeEdgeFunctionFromEntry(mapEntry, edgeFunctionIndex)">
                                         remove
                                       </a>
                                     </td>
                                   </tr>
                                 </template>
-                                <tr v-if="cloudFunctionNewEntryMode(mapIndex)"
-                                    class="new-cloud-function-row">
+                                <tr v-if="edgeFunctionNewEntryMode(mapIndex)"
+                                    class="new-edge-function-row">
                                   <td colspan="3">
                                     <div class="control is-expanded">
                                       <div class="select is-small is-size-7 is-fullwidth">
-                                        <select class="select is-small new-cloud-function-selection"
-                                                title="Cloud Function ID"
-                                                v-model="cloudFunctionMapEntryId">
-                                          <option v-for="cloudFunction in newCloudFunctions(mapEntry.cloud_functions)"
-                                                  :key="cloudFunction.id"
-                                                  :value="cloudFunction.id">
-                                            {{ cloudFunction.name + ' ' + cloudFunction.description }}
+                                        <select class="select is-small new-edge-function-selection"
+                                                title="Edge Function ID"
+                                                v-model="edgeFunctionMapEntryId">
+                                          <option v-for="edgeFunction in newEdgeFunctions(mapEntry.cloud_functions)"
+                                                  :key="edgeFunction.id"
+                                                  :value="edgeFunction.id">
+                                            {{ edgeFunction.name + ' ' + edgeFunction.description }}
                                           </option>
                                         </select>
                                       </div>
                                     </div>
                                   </td>
                                   <td class="has-text-centered is-size-7 width-60px">
-                                    <a class="is-small has-text-grey cloud-function-confirm-add-button"
+                                    <a class="is-small has-text-grey edge-function-confirm-add-button"
                                        title="Add this entry"
                                        tabindex="0"
-                                       @click="addCloudFunctionToEntry(mapEntry, cloudFunctionMapEntryId)"
+                                       @click="addEdgeFunctionToEntry(mapEntry, edgeFunctionMapEntryId)"
                                        @keypress.space.prevent
-                                       @keypress.space="addCloudFunctionToEntry(mapEntry, cloudFunctionMapEntryId)"
-                                       @keypress.enter="addCloudFunctionToEntry(mapEntry, cloudFunctionMapEntryId)">
+                                       @keypress.space="addEdgeFunctionToEntry(mapEntry, edgeFunctionMapEntryId)"
+                                       @keypress.enter="addEdgeFunctionToEntry(mapEntry, edgeFunctionMapEntryId)">
                                       add
                                     </a>
                                   </td>
                                 </tr>
-                                <tr v-if="mapEntry.cloud_functions && !existingCloudFunctionIDs(mapEntry).length">
+                                <tr v-if="mapEntry.cloud_functions && !existingEdgeFunctionIDs(mapEntry).length">
                                   <td colspan="5">
                                     <p class="is-size-7 has-text-grey has-text-centered">
-                                      To attach an existing Cloud Function, click
-                                      <a class="cloud-function-text-add-button"
+                                      To attach an existing Edge Function, click
+                                      <a class="edge-function-text-add-button"
                                          title="Add New"
-                                         @click="cloudFunctionNewEntryModeMapEntryId = mapIndex">here</a>.
+                                         @click="edgeFunctionNewEntryModeMapEntryId = mapIndex">here</a>.
                                       <br/>
-                                      To create a new Cloud Function, click
-                                      <a class="cloud-function-referral-button"
-                                         @click="referToCloudFunction">here</a>.
+                                      To create a new Edge Function, click
+                                      <a class="edge-function-referral-button"
+                                         @click="referToEdgeFunction">here</a>.
                                     </p>
                                   </td>
                                 </tr>
@@ -331,7 +343,7 @@
               </tbody>
             </table>
           </div>
-          <span class="is-family-monospace has-text-grey-lighter">{{ documentAPIPath }}</span>
+          <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ documentAPIPath }}</span>
         </div>
       </div>
     </div>
@@ -340,7 +352,7 @@
 <script lang="ts">
 import _ from 'lodash'
 import RequestsUtils from '@/assets/RequestsUtils'
-import {BackendService, CloudFunction, RoutingProfile, RoutingProfileEntryLocation} from '@/types'
+import {BackendService, EdgeFunction, RoutingProfile, RoutingProfileEntryLocation} from '@/types'
 import Utils from '@/assets/Utils'
 import {defineComponent} from 'vue'
 import DatasetsUtils from '@/assets/DatasetsUtils'
@@ -366,9 +378,9 @@ export default defineComponent({
       initialMapEntryPath: '',
       entriesLocationNames: [] as RoutingProfileEntryLocation['path'][],
       backendServiceNames: [] as [BackendService['id'], BackendService['name']][],
-      cloudFunctions: [] as CloudFunction[],
-      cloudFunctionNewEntryModeMapEntryId: null,
-      cloudFunctionMapEntryId: null,
+      edgeFunctions: [] as EdgeFunction[],
+      edgeFunctionNewEntryModeMapEntryId: null,
+      edgeFunctionMapEntryId: null,
       matchingPathTitle: 'A unique matching regex value, not overlapping other path mapping definitions',
 
       apiRoot: RequestsUtils.reblazeAPIRoot,
@@ -380,7 +392,7 @@ export default defineComponent({
       handler: function(val, oldVal) {
         if ((this.$route.name as string).includes('RoutingProfiles/config') && val && val !== oldVal) {
           this.loadBackendServices()
-          this.loadCloudFunctions()
+          this.loadEdgeFunctions()
           this.setSelectedDataFromRouteParams()
         }
       },
@@ -495,37 +507,37 @@ export default defineComponent({
       return backendService?.[1] || ''
     },
 
-    newCloudFunctions(currentCloudFunctionIDs: string[]): CloudFunction[] {
-      return _.filter(this.cloudFunctions, (cloudFunction) => {
-        return _.indexOf(currentCloudFunctionIDs, cloudFunction.id) === -1
+    newEdgeFunctions(currentEdgeFunctionIDs: string[]): EdgeFunction[] {
+      return _.filter(this.edgeFunctions, (edgeFunction) => {
+        return _.indexOf(currentEdgeFunctionIDs, edgeFunction.id) === -1
       })
     },
 
-    addCloudFunctionToEntry(mapEntry: RoutingProfileEntryLocation, id: string) {
+    addEdgeFunctionToEntry(mapEntry: RoutingProfileEntryLocation, id: string) {
       if (id) {
         mapEntry.cloud_functions.push(id)
-        this.cloudFunctionNewEntryModeMapEntryId = null
-        this.cloudFunctionMapEntryId = null
+        this.edgeFunctionNewEntryModeMapEntryId = null
+        this.edgeFunctionMapEntryId = null
       }
     },
 
-    removeCloudFunctionFromEntry(mapEntry: RoutingProfileEntryLocation, index: number) {
+    removeEdgeFunctionFromEntry(mapEntry: RoutingProfileEntryLocation, index: number) {
       mapEntry.cloud_functions.splice(index, 1)
     },
 
-    cloudFunctionsDetails(cloudFunctionId: CloudFunction['id']): CloudFunction {
-      return _.find(this.cloudFunctions, (cloudFunction) => {
-        return cloudFunction.id === cloudFunctionId
+    edgeFunctionsDetails(edgeFunctionId: EdgeFunction['id']): EdgeFunction {
+      return _.find(this.edgeFunctions, (edgeFunction) => {
+        return edgeFunction.id === edgeFunctionId
       })
     },
 
-    cloudFunctionNewEntryMode(id: number): boolean {
-      return this.cloudFunctionNewEntryModeMapEntryId === id
+    edgeFunctionNewEntryMode(id: number): boolean {
+      return this.edgeFunctionNewEntryModeMapEntryId === id
     },
 
-    existingCloudFunctionIDs(mapEntry: RoutingProfileEntryLocation): CloudFunction['id'][] {
-      return _.filter(mapEntry.cloud_functions, (cloudFunctionId) => {
-        return this.cloudFunctionsDetails(cloudFunctionId) !== undefined
+    existingEdgeFunctionIDs(mapEntry: RoutingProfileEntryLocation): EdgeFunction['id'][] {
+      return _.filter(mapEntry.cloud_functions, (edgeFunctionId) => {
+        return this.edgeFunctionsDetails(edgeFunctionId) !== undefined
       })
     },
 
@@ -573,8 +585,8 @@ export default defineComponent({
       this.selectedRoutingProfile.locations.splice(index, 1)
     },
 
-    referToCloudFunction() {
-      this.$emit('go-to-route', `/config/${this.selectedBranch}/cloud-functions`)
+    referToEdgeFunction() {
+      this.$emit('go-to-route', `/config/${this.selectedBranch}/edge-functions`)
     },
 
     loadBackendServices() {
@@ -591,12 +603,12 @@ export default defineComponent({
       })
     },
 
-    loadCloudFunctions() {
+    loadEdgeFunctions() {
       RequestsUtils.sendReblazeRequest({
         methodName: 'GET',
         url: `configs/${this.selectedBranch}/d/cloud-functions/`,
-      }).then((response: AxiosResponse<CloudFunction[]>) => {
-        this.cloudFunctions = response.data
+      }).then((response: AxiosResponse<EdgeFunction[]>) => {
+        this.edgeFunctions = response.data
       })
     },
   },

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -378,7 +378,7 @@
           </tbody>
         </table>
       </div>
-      <span class="is-family-monospace has-text-grey-lighter">{{ apiPath }}</span>
+      <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ apiPath }}</span>
     </div>
   </div>
 </template>

--- a/src/doc-editors/ServerGroupsEditor.vue
+++ b/src/doc-editors/ServerGroupsEditor.vue
@@ -10,20 +10,12 @@
                         @click="redirectToList()"
                         title="Return to list"
                         data-qa="redirect-to-list">
-                        <span class="icon is-small">
-                          <i class="fas fa-arrow-left"></i>
-                        </span>
-                </button>
-              </p>
-              <p class="control">
-                <button class="button is-small download-doc-button"
-                        :class="{'is-loading':isDownloadLoading}"
-                        @click="downloadDoc()"
-                        title="Download document"
-                        data-qa="download-document">
-                        <span class="icon is-small">
-                          <i class="fas fa-download"></i>
-                        </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-arrow-left"></i>
+                  </span>
+                  <span>
+                    Return To List
+                  </span>
                 </button>
               </p>
             </div>
@@ -31,14 +23,31 @@
           <div class="column">
             <div class="field is-grouped is-pulled-right">
               <p class="control">
+                <button class="button is-small download-doc-button"
+                        :class="{'is-loading':isDownloadLoading}"
+                        @click="downloadDoc()"
+                        title="Download document"
+                        data-qa="download-document">
+                  <span class="icon is-small">
+                    <i class="fas fa-download"></i>
+                  </span>
+                  <span>
+                    Download
+                  </span>
+                </button>
+              </p>
+              <p class="control">
                 <button class="button is-small save-document-button"
                         :class="{'is-loading': isSaveLoading}"
                         title="Save changes"
                         data-qa="save-changes"
                         @click="saveChanges()">
-                      <span class="icon is-small">
-                        <i class="fas fa-save"></i>
-                      </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-save"></i>
+                  </span>
+                  <span>
+                    Save
+                  </span>
                 </button>
               </p>
               <p class="control">
@@ -46,11 +55,14 @@
                         title="Delete document"
                         data-qa="delete-document"
                         :class="{'is-loading': isDeleteLoading}"
-                        :disabled="selectedWebProxy?.id === '__default__'"
+                        :disabled="selectedServerGroup?.id === '__default__'"
                         @click="deleteDoc()">
-                      <span class="icon is-small">
-                        <i class="fas fa-trash"></i>
-                      </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-trash"></i>
+                  </span>
+                  <span>
+                    Delete
+                  </span>
                 </button>
               </p>
             </div>
@@ -62,7 +74,7 @@
     <div class="card">
       <div class="card-content">
         <div class="content"
-             v-if="selectedWebProxy">
+             v-if="selectedServerGroup">
           <div class="columns columns-divided">
             <div class="column is-4">
               <div class="field">
@@ -70,14 +82,14 @@
                   Name
                   <span class="has-text-grey is-pulled-right document-id"
                         title="Rule id">
-                      {{ selectedWebProxy.id }}
+                      {{ selectedServerGroup.id }}
                     </span>
                 </label>
                 <div class="control">
                   <input class="input is-small document-name"
                          title="Document name"
                          placeholder="Document name"
-                         v-model="selectedWebProxy.name"/>
+                         v-model="selectedServerGroup.name"/>
                 </div>
               </div>
               <div class="field">
@@ -87,7 +99,7 @@
                       <textarea class="is-small textarea document-description"
                                 data-qa="description-input"
                                 title="Document description"
-                                v-model="selectedWebProxy.description"
+                                v-model="selectedServerGroup.description"
                                 rows="5">
                       </textarea>
                   </div>
@@ -103,7 +115,7 @@
                   <input class="input is-small domain-name"
                          title="Domain name"
                          placeholder="Domain name"
-                         v-model="selectedWebProxy.canonical_name"/>
+                         v-model="selectedServerGroup.canonical_name"/>
                 </div>
               </div>
               <div class="field">
@@ -124,7 +136,7 @@
                 <label class="label is-small">Routing Profile</label>
                 <div class="control is-expanded">
                   <div class="select is-fullwidth is-small">
-                    <select v-model="selectedWebProxy.routing_profile"
+                    <select v-model="selectedServerGroup.routing_profile"
                             data-qa="routing-profile-dropdown"
                             class="document-routing-profile-selection"
                             title="Routing profile">
@@ -152,7 +164,7 @@
                         Backend Service
                       </th>
                       <th class="width-120px">
-                        Cloud Functions
+                        Edge Functions
                       </th>
                     </tr>
                     </thead>
@@ -166,8 +178,8 @@
                         {{ referencedDocName(backendServicesNames, location.backend_id) }}
                       </td>
                       <td>
-                          <span v-for="cloudFunction in location.cloud_functions"
-                                :key="cloudFunction">
+                          <span v-for="edgeFunction in location.cloud_functions"
+                                :key="edgeFunction">
                             {{ location.cloud_functions.length }}
                           </span>
                       </td>
@@ -184,7 +196,7 @@
                 <label class="label is-small">Security Policy</label>
                 <div class="control is-expanded">
                   <div class="select is-fullwidth is-small">
-                    <select v-model="selectedWebProxy.security_policy"
+                    <select v-model="selectedServerGroup.security_policy"
                             data-qa="security-policy-dropdown"
                             class="document-security-policy-selection"
                             title="Security policy">
@@ -249,7 +261,7 @@
                 <label class="label is-small">Mobile SDK</label>
                 <div class="control is-expanded">
                   <div class="select is-fullwidth is-small">
-                    <select v-model="selectedWebProxy.mobile_sdk"
+                    <select v-model="selectedServerGroup.mobile_sdk"
                             data-qa="mobile-sdk-dropdown"
                             class="document-mobile-sdk-selection"
                             title="Mobile SDK">
@@ -266,17 +278,17 @@
                 </div>
               </div>
               <div class="field">
-                <label class="label is-small">Proxy Template</label>
+                <label class="label is-small">Config Template</label>
                 <div class="control is-expanded">
                   <div class="select is-fullwidth is-small">
-                    <select v-model="selectedWebProxy.proxy_template"
-                            data-qa="proxy-template-dropdown"
-                            class="document-proxy-template-selection"
-                            title="Proxy template">
-                      <option v-for="proxyTemplate in proxyTemplatesNames"
-                              :value="proxyTemplate[0]"
-                              :key="proxyTemplate[0]">
-                        {{ proxyTemplate[1] }}
+                    <select v-model="selectedServerGroup.proxy_template"
+                            data-qa="config-template-dropdown"
+                            class="document-config-template-selection"
+                            title="Config template">
+                      <option v-for="configTemplate in configTemplatesNames"
+                              :value="configTemplate[0]"
+                              :key="configTemplate[0]">
+                        {{ configTemplate[1] }}
                       </option>
                     </select>
                   </div>
@@ -284,7 +296,7 @@
               </div>
             </div>
           </div>
-          <span class="is-family-monospace has-text-grey-lighter">{{ documentAPIPath }}</span>
+          <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">{{ documentAPIPath }}</span>
         </div>
       </div>
     </div>
@@ -298,7 +310,7 @@ import {
   BackendService,
   ContentFilterProfile,
   MobileSDK,
-  ProxyTemplate,
+  ConfigTemplate,
   RoutingProfile,
   SecurityPolicy,
   Site,
@@ -311,11 +323,11 @@ import {mapStores} from 'pinia'
 import {useBranchesStore} from '@/stores/BranchesStore'
 
 export default defineComponent({
-  name: 'WebProxyEditor',
+  name: 'ServerGroupsEditor',
   data() {
     return {
       titles: DatasetsUtils.titles,
-      selectedWebProxy: null as Site,
+      selectedServerGroup: null as Site,
       docIdFromRoute: '',
 
       // Loading indicators
@@ -329,7 +341,7 @@ export default defineComponent({
       securityPoliciesNames: [] as [SecurityPolicy['id'], SecurityPolicy['name']][],
       routingProfiles: [] as RoutingProfile[],
       routingProfilesNames: [] as [RoutingProfile['id'], RoutingProfile['name']][],
-      proxyTemplatesNames: [] as [ProxyTemplate['id'], ProxyTemplate['name']][],
+      configTemplatesNames: [] as [ConfigTemplate['id'], ConfigTemplate['name']][],
       mobileSDKsNames: [] as [MobileSDK['id'], MobileSDK['name']][],
       backendServicesNames: [] as [BackendService['id'], BackendService['name']][],
       contentFilterProfilesNames: [] as [ContentFilterProfile['id'], ContentFilterProfile['name']][],
@@ -342,11 +354,11 @@ export default defineComponent({
   watch: {
     selectedBranch: {
       handler: function(val, oldVal) {
-        if ((this.$route.name as string).includes('WebProxy/config') && val && val !== oldVal) {
+        if ((this.$route.name as string).includes('ServerGroups/config') && val && val !== oldVal) {
           this.setSelectedDataFromRouteParams()
           this.loadSecurityPolicies()
           this.loadRoutingProfiles()
-          this.loadProxyTemplates()
+          this.loadConfigTemplates()
           this.loadMobileSDKs()
           this.loadBackendServices()
           this.loadContentFilterProfiles()
@@ -359,28 +371,28 @@ export default defineComponent({
   computed: {
     documentAPIPath(): string {
       const apiPrefix = `${this.apiRoot}/${this.apiVersion}`
-      return `${apiPrefix}/reblaze/configs/${this.selectedBranch}/d/sites/e/${this.selectedWebProxy.id}/`
+      return `${apiPrefix}/reblaze/configs/${this.selectedBranch}/d/sites/e/${this.selectedServerGroup.id}/`
     },
 
     selectedSecurityPolicy(): SecurityPolicy {
       return this.securityPolicies.find((securityPolicy) => {
-        return securityPolicy.id === this.selectedWebProxy.security_policy
+        return securityPolicy.id === this.selectedServerGroup.security_policy
       })
     },
 
     selectedRoutingProfile(): RoutingProfile {
       return this.routingProfiles.find((routingProfile) => {
-        return routingProfile.id === this.selectedWebProxy.routing_profile
+        return routingProfile.id === this.selectedServerGroup.routing_profile
       })
     },
 
     serverNames: {
       get() {
-        return Array.from(this.selectedWebProxy.server_names || '').join('\n')
+        return Array.from(this.selectedServerGroup.server_names || '').join('\n')
       },
       set(newValue: string) {
         const value = newValue.replaceAll(' ', '')
-        this.selectedWebProxy.server_names = value.split('\n')
+        this.selectedServerGroup.server_names = value.split('\n')
       },
     },
 
@@ -394,11 +406,11 @@ export default defineComponent({
     async setSelectedDataFromRouteParams() {
       this.setLoadingDocStatus(true)
       this.docIdFromRoute = this.$route.params?.doc_id?.toString()
-      await this.loadWebProxy()
+      await this.loadServerGroup()
     },
 
     redirectToList() {
-      this.$router.push(`/${this.selectedBranch}/web-proxy/list`)
+      this.$router.push(`/${this.selectedBranch}/server-groups/list`)
     },
 
     setLoadingDocStatus(isLoading: boolean) {
@@ -412,23 +424,23 @@ export default defineComponent({
     async switchBranch() {
       this.setLoadingDocStatus(true)
       Utils.toast(`Switched to branch '${this.selectedBranch}'.`, 'is-info')
-      await this.loadWebProxy()
+      await this.loadServerGroup()
       this.setLoadingDocStatus(false)
     },
 
     downloadDoc() {
       if (!this.isDownloadLoading) {
-        Utils.downloadFile('web-proxy', 'json', this.selectedWebProxy)
+        Utils.downloadFile('server-groups', 'json', this.selectedServerGroup)
       }
     },
 
     async deleteDoc() {
       this.setLoadingDocStatus(true)
       this.isDeleteLoading = true
-      const webProxyText = this.titles['sites-singular']
-      const url = `configs/${this.selectedBranch}/d/sites/e/${this.selectedWebProxy.id}/`
-      const successMessage = `The ${webProxyText} was deleted.`
-      const failureMessage = `Failed while attempting to delete the ${webProxyText}.`
+      const serverGroupText = this.titles['sites-singular']
+      const url = `configs/${this.selectedBranch}/d/sites/e/${this.selectedServerGroup.id}/`
+      const successMessage = `The ${serverGroupText} was deleted.`
+      const failureMessage = `Failed while attempting to delete the ${serverGroupText}.`
       await RequestsUtils.sendReblazeRequest({
         methodName: 'DELETE',
         url: url,
@@ -443,27 +455,27 @@ export default defineComponent({
     async saveChanges() {
       this.isSaveLoading = true
       const methodName = 'PUT'
-      const url = `configs/${this.selectedBranch}/d/sites/e/${this.selectedWebProxy.id}/`
-      const data = this.selectedWebProxy
-      const webProxyText = this.titles['sites-singular']
-      const successMessage = `Changes to the ${webProxyText} were saved.`
-      const failureMessage = `Failed while attempting to save the changes to the ${webProxyText}.`
+      const url = `configs/${this.selectedBranch}/d/sites/e/${this.selectedServerGroup.id}/`
+      const data = this.selectedServerGroup
+      const serverGroupText = this.titles['sites-singular']
+      const successMessage = `Changes to the ${serverGroupText} were saved.`
+      const failureMessage = `Failed while attempting to save the changes to the ${serverGroupText}.`
       await RequestsUtils.sendReblazeRequest({methodName, url, data, successMessage, failureMessage})
       this.isSaveLoading = false
     },
 
-    async loadWebProxy() {
+    async loadServerGroup() {
       this.isDownloadLoading = true
       const response = await RequestsUtils.sendReblazeRequest({
         methodName: 'GET',
         url: `configs/${this.selectedBranch}/d/sites/e/${this.docIdFromRoute}`,
         onFail: () => {
-          console.log('Error while attempting to load the Web Proxy')
-          this.selectedWebProxy = null
+          console.log(`Error while attempting to load the ${this.titles['sites-singular']}`)
+          this.selectedServerGroup = null
           this.isDownloadLoading = false
         },
       })
-      this.selectedWebProxy = response?.data || {}
+      this.selectedServerGroup = response?.data || {}
       this.isDownloadLoading = false
     },
 
@@ -495,13 +507,13 @@ export default defineComponent({
       })
     },
 
-    loadProxyTemplates() {
+    loadConfigTemplates() {
       RequestsUtils.sendReblazeRequest({
         methodName: 'GET',
         url: `configs/${this.selectedBranch}/d/proxy-templates/`,
         config: {headers: {'x-fields': 'id, name'}},
-      }).then((response: AxiosResponse<ProxyTemplate[]>) => {
-        this.proxyTemplatesNames = _.sortBy(_.map(response.data, (entity) => {
+      }).then((response: AxiosResponse<ConfigTemplate[]>) => {
+        this.configTemplatesNames = _.sortBy(_.map(response.data, (entity) => {
           return [entity.id, entity.name]
         }), (e) => {
           return e[1]

--- a/src/doc-editors/__tests__/CloudFunctionsEditor.spec.ts
+++ b/src/doc-editors/__tests__/CloudFunctionsEditor.spec.ts
@@ -1,32 +1,32 @@
 // @ts-nocheck
-import CloudFunctionsEditor from '@/doc-editors/CloudFunctionsEditor.vue'
+import EdgeFunctionsEditor from '@/doc-editors/EdgeFunctionsEditor.vue'
 import {afterEach, beforeEach, describe, expect, jest, test} from '@jest/globals'
 import {mount, VueWrapper} from '@vue/test-utils'
-import {CloudFunction, SecurityPolicy} from '@/types'
+import {EdgeFunction, SecurityPolicy} from '@/types'
 import axios from 'axios'
 
 jest.mock('axios')
 
-describe('CloudFunctionsEditor.vue', () => {
+describe('EdgeFunctionsEditor.vue', () => {
   let securityPoliciesDocs: SecurityPolicy[]
-  let cloudFunctionsDocs: CloudFunction[]
+  let edgeFunctionsDocs: EdgeFunction[]
   let mockRouter: any
   let wrapper: VueWrapper
   beforeEach(() => {
-    cloudFunctionsDocs = [{
+    edgeFunctionsDocs = [{
       'id': 'f971e92459e2',
-      'name': 'New Cloud Functions',
+      'name': 'New Edge Functions',
       'description': '5 requests per minute',
-      'phase': 'request1',
+      'phase': 'request',
       'code': `-- begin custom code
       --custom response header
       ngx.header['foo'] = 'bar'`,
     },
     {
       'id': 'f123456789',
-      'name': 'New Cloud Function',
+      'name': 'New Edge Function',
       'description': '2 requests per minute',
-      'phase': 'response0',
+      'phase': 'response',
       'code': `-- begin custom code
       --custom response header
       ngx.header['foo'] = 'bar'`,
@@ -93,12 +93,12 @@ describe('CloudFunctionsEditor.vue', () => {
     mockRouter = {
       push: jest.fn(),
     }
-    const onUpdate = async (selectedDoc: CloudFunctions) => {
+    const onUpdate = async (selectedDoc: EdgeFunctions) => {
       await wrapper.setProps({selectedDoc})
     }
-    wrapper = mount(CloudFunctionsEditor, {
+    wrapper = mount(EdgeFunctionsEditor, {
       props: {
-        'selectedDoc': cloudFunctionsDocs[0],
+        'selectedDoc': edgeFunctionsDocs[0],
         'selectedBranch': selectedBranch,
         'onUpdate:selectedDoc': onUpdate,
       },
@@ -117,22 +117,22 @@ describe('CloudFunctionsEditor.vue', () => {
     })
 
     test('should have correct ID displayed', () => {
-      expect(wrapper.find('.document-id').text()).toEqual(cloudFunctionsDocs[0].id)
+      expect(wrapper.find('.document-id').text()).toEqual(edgeFunctionsDocs[0].id)
     })
 
     test('should have correct name in input', () => {
       const element = wrapper.find('.document-name').element as HTMLInputElement
-      expect(element.value).toEqual(cloudFunctionsDocs[0].name)
+      expect(element.value).toEqual(edgeFunctionsDocs[0].name)
     })
 
     test('should have correct description in input', () => {
       const element = wrapper.find('.document-description').element as HTMLInputElement
-      expect(element.value).toEqual(cloudFunctionsDocs[0].description)
+      expect(element.value).toEqual(edgeFunctionsDocs[0].description)
     })
 
     test('should have correct phase in dropdown', () => {
       const element = wrapper.find('.phase-selection').element as HTMLInputElement
-      expect(element.value).toEqual(cloudFunctionsDocs[0].phase)
+      expect(element.value).toEqual(edgeFunctionsDocs[0].phase)
     })
 
     test('should emit correct data after input was changed', async () => {

--- a/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
+++ b/src/doc-editors/__tests__/ContentFilterProfileEditor.spec.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import ContentFilterEditor from '@/doc-editors/ContentFilterProfileEditor.vue'
+import ContentFilterEditor from '../ContentFilterProfilesEditor.vue'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import {beforeEach, describe, expect, jest, test} from '@jest/globals'
 import {shallowMount} from '@vue/test-utils'
@@ -18,7 +18,7 @@ import {nextTick} from 'vue'
 
 jest.mock('axios')
 
-describe('ContentFilterProfileEditor.vue', () => {
+describe('ContentFilterProfilesEditor.vue', () => {
   let docs: ContentFilterProfile[]
   let wrapper: any
   let contentFilterRulesDocs: ContentFilterRule[]

--- a/src/doc-editors/__tests__/CustomResponseEditor.spec.ts
+++ b/src/doc-editors/__tests__/CustomResponseEditor.spec.ts
@@ -1,10 +1,10 @@
 // @ts-nocheck
-import CustomResponseEditor from '@/doc-editors/CustomResponseEditor.vue'
+import CustomResponseEditor from '../CustomResponsesEditor.vue'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import {beforeEach, describe, expect, test} from '@jest/globals'
 import {shallowMount, VueWrapper} from '@vue/test-utils'
 
-describe('CustomResponseEditor.vue', () => {
+describe('CustomResponsesEditor.vue', () => {
   let docs: ContentFilterRule[]
   let wrapper: VueWrapper
   beforeEach(() => {

--- a/src/doc-editors/__tests__/FlowControlPolicyEditor.spec.ts
+++ b/src/doc-editors/__tests__/FlowControlPolicyEditor.spec.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import FlowControlPolicyEditor from '@/doc-editors/FlowControlPolicyEditor.vue'
+import FlowControlPolicyEditor from '../FlowControlPoliciesEditor.vue'
 import LimitOption from '@/components/LimitOption.vue'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import {beforeEach, describe, expect, test, jest} from '@jest/globals'
@@ -11,7 +11,7 @@ import {nextTick} from 'vue'
 
 jest.mock('axios')
 
-describe('FlowControlPolicyEditor.vue', () => {
+describe('FlowControlPoliciesEditor.vue', () => {
   let docs: FlowControlPolicy[]
   let wrapper: VueWrapper
   beforeEach(() => {

--- a/src/doc-editors/__tests__/GlobalFilterListEditor.spec.ts
+++ b/src/doc-editors/__tests__/GlobalFilterListEditor.spec.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
-import GlobalFilterListEditor from '@/doc-editors/GlobalFilterListEditor.vue'
+import GlobalFilterListEditor from '../GlobalFiltersEditor.vue'
 import {beforeEach, describe, expect, jest, test} from '@jest/globals'
 import {mount, shallowMount, VueWrapper} from '@vue/test-utils'
-import {CustomResponse, GlobalFilter, GlobalFilterSectionEntry} from '@/types'
+import {CustomResponse, GlobalFilter, GlobalFilterRuleEntry} from '@/types'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import EntriesRelationList from '@/components/EntriesRelationList.vue'
 import axios from 'axios'
@@ -10,7 +10,7 @@ import {nextTick} from 'vue'
 
 jest.mock('axios')
 
-describe('GlobalFilterListEditor.vue', () => {
+describe('GlobalFiltersEditor.vue', () => {
   let docs: GlobalFilter[]
   let customResponsesDocs: CustomResponse[]
   let wrapper: VueWrapper
@@ -126,10 +126,10 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should have response action selection with correct data', () => {
-      const wantedAction = docs[0].action.toString()
+      const wantedCustomResponse = docs[0].action.toString()
       const actionSelection = wrapper.find('.document-action-selection')
-      const selectedAction = (actionSelection.find('option:checked').element as HTMLOptionElement).value
-      expect(selectedAction).toEqual(wantedAction)
+      const selectedCustomResponse = (actionSelection.find('option:checked').element as HTMLOptionElement).value
+      expect(selectedCustomResponse).toEqual(wantedCustomResponse)
     })
 
     test('should have correct description in input', () => {
@@ -421,7 +421,7 @@ describe('GlobalFilterListEditor.vue', () => {
         selectedDoc: docs[0],
       },
     })
-    const wantedRule: GlobalFilter['rule'] = {
+    const wantedRule: GlobalFilterRule = {
       relation: docs[0].rule.relation,
       entries: [],
     }
@@ -450,7 +450,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should update entries relation component with correct data - ipv4 array', async () => {
-      const wantedEntries: GlobalFilterSectionEntry[] = [
+      const wantedEntries: GlobalFilterRuleEntry[] = [
         [
           'ip',
           '203.208.60.0/24',
@@ -467,7 +467,7 @@ describe('GlobalFilterListEditor.vue', () => {
           'Crawler',
         ],
       ]
-      const wantedData: GlobalFilter['rule'] = {
+      const wantedData: GlobalFilterRule = {
         relation: 'OR',
         entries: [{
           entries: wantedEntries,
@@ -500,7 +500,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should update entries relation component with correct data - ipv6 array', async () => {
-      const wantedEntries: GlobalFilterSectionEntry[] = [
+      const wantedEntries: GlobalFilterRuleEntry[] = [
         [
           'ip',
           '2603:8080:3d40:f7:d45b:477e:579e:245',
@@ -517,7 +517,7 @@ describe('GlobalFilterListEditor.vue', () => {
           'Crawler',
         ],
       ]
-      const wantedData: GlobalFilter['rule'] = {
+      const wantedData: GlobalFilterRule = {
         relation: 'OR',
         entries: [{
           entries: wantedEntries,
@@ -550,7 +550,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should update entries relation component with correct data - asn array', async () => {
-      const wantedEntries: GlobalFilterSectionEntry[] = [
+      const wantedEntries: GlobalFilterRuleEntry[] = [
         [
           'asn',
           'as34109',
@@ -567,7 +567,7 @@ describe('GlobalFilterListEditor.vue', () => {
           'spam',
         ],
       ]
-      const wantedData: GlobalFilter['rule'] = {
+      const wantedData: GlobalFilterRule = {
         relation: 'OR',
         entries: [{
           entries: wantedEntries,
@@ -600,7 +600,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should update entries relation component with correct data - ip singles', async () => {
-      const wantedEntries: GlobalFilterSectionEntry[] = [
+      const wantedEntries: GlobalFilterRuleEntry[] = [
         [
           'ip',
           '203.208.60.0/24',
@@ -617,7 +617,7 @@ describe('GlobalFilterListEditor.vue', () => {
           null,
         ],
       ]
-      const wantedData: GlobalFilter['rule'] = {
+      const wantedData: GlobalFilterRule = {
         relation: 'OR',
         entries: [{
           entries: wantedEntries,
@@ -641,7 +641,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should update entries relation component with correct data - asn singles', async () => {
-      const wantedEntries: GlobalFilterSectionEntry[] = [
+      const wantedEntries: GlobalFilterRuleEntry[] = [
         [
           'asn',
           'as34109',
@@ -658,7 +658,7 @@ describe('GlobalFilterListEditor.vue', () => {
           null,
         ],
       ]
-      const wantedData: GlobalFilter['rule'] = {
+      const wantedData: GlobalFilterRule = {
         relation: 'OR',
         entries: [{
           entries: wantedEntries,
@@ -682,7 +682,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should update entries relation component with correct data - ip inside object', async () => {
-      const wantedEntries: GlobalFilterSectionEntry[] = [
+      const wantedEntries: GlobalFilterRuleEntry[] = [
         [
           'ip',
           '203.208.60.0/24',
@@ -699,7 +699,7 @@ describe('GlobalFilterListEditor.vue', () => {
           'Crawler',
         ],
       ]
-      const wantedData: GlobalFilter['rule'] = {
+      const wantedData: GlobalFilterRule = {
         relation: 'OR',
         entries: [{
           entries: wantedEntries,
@@ -735,7 +735,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should update entries relation component with correct data - asn inside object', async () => {
-      const wantedEntries: GlobalFilterSectionEntry[] = [
+      const wantedEntries: GlobalFilterRuleEntry[] = [
         [
           'asn',
           'as34109',
@@ -752,7 +752,7 @@ describe('GlobalFilterListEditor.vue', () => {
           'spam',
         ],
       ]
-      const wantedData: GlobalFilter['rule'] = {
+      const wantedData: GlobalFilterRule = {
         relation: 'OR',
         entries: [{
           entries: wantedEntries,
@@ -788,7 +788,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should update entries relation component with correct data - ip array', async () => {
-      const wantedEntries: GlobalFilterSectionEntry[] = [
+      const wantedEntries: GlobalFilterRuleEntry[] = [
         [
           'ip',
           '203.208.60.0/24',
@@ -810,7 +810,7 @@ describe('GlobalFilterListEditor.vue', () => {
           null,
         ],
       ]
-      const wantedData: GlobalFilter['rule'] = {
+      const wantedData: GlobalFilterRule = {
         relation: 'OR',
         entries: [{
           entries: wantedEntries,
@@ -832,7 +832,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should update entries relation component with correct data - asn array', async () => {
-      const wantedEntries: GlobalFilterSectionEntry[] = [
+      const wantedEntries: GlobalFilterRuleEntry[] = [
         [
           'asn',
           'as34109',
@@ -854,7 +854,7 @@ describe('GlobalFilterListEditor.vue', () => {
           null,
         ],
       ]
-      const wantedData: GlobalFilter['rule'] = {
+      const wantedData: GlobalFilterRule = {
         relation: 'OR',
         entries: [{
           entries: wantedEntries,
@@ -895,7 +895,7 @@ describe('GlobalFilterListEditor.vue', () => {
           ],
         },
       }
-      const wantedData: GlobalFilter['rule'] = JSON.parse(JSON.stringify(globalFilter.rule))
+      const wantedData: GlobalFilterRule = JSON.parse(JSON.stringify(globalFilter.rule))
       resolveData = {data: globalFilter}
       const button = wrapper.find('.update-now-button')
       await button.trigger('click')
@@ -906,7 +906,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should not update entries relation component with correct data - global filter - no entries', async () => {
-      const wantedData: GlobalFilter['rule'] = docs[0].rule
+      const wantedData: GlobalFilterRule = docs[0].rule
       resolveData = {
         data: {
           'id': 'xlbp148c',
@@ -932,7 +932,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should not update entries relation component with correct data - global filter - no sections', async () => {
-      const wantedData: GlobalFilter['rule'] = docs[0].rule
+      const wantedData: GlobalFilterRule = docs[0].rule
       resolveData = {
         data: {
           'id': 'xlbp148c',
@@ -957,7 +957,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should not update entries relation component with correct data - global filter - no rule', async () => {
-      const wantedData: GlobalFilter['rule'] = docs[0].rule
+      const wantedData: GlobalFilterRule = docs[0].rule
       resolveData = {
         data: {
           'id': 'xlbp148c',
@@ -979,7 +979,7 @@ describe('GlobalFilterListEditor.vue', () => {
     })
 
     test('should not update entries relation component when no data found', async () => {
-      const wantedData: GlobalFilter['rule'] = docs[0].rule
+      const wantedData: GlobalFilterRule = docs[0].rule
       resolveData = {
         data: null,
       }

--- a/src/doc-editors/__tests__/RateLimitsEditor.spec.ts
+++ b/src/doc-editors/__tests__/RateLimitsEditor.spec.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import RateLimitsEditor from '@/doc-editors/RateLimitsEditor.vue'
+import RateLimitsEditor from '../RateLimitRulesEditor.vue'
 import LimitOption from '@/components/LimitOption.vue'
 import {afterEach, beforeEach, describe, expect, jest, test} from '@jest/globals'
 import {mount, shallowMount, VueWrapper} from '@vue/test-utils'
@@ -10,7 +10,7 @@ import {nextTick} from 'vue'
 
 jest.mock('axios')
 
-describe('RateLimitsEditor.vue', () => {
+describe('RateLimitRulesEditor.vue', () => {
   let rateLimitsDocs: RateLimit[]
   let securityPoliciesDocs: SecurityPolicy[]
   let customResponsesDocs: CustomResponse[]
@@ -30,7 +30,7 @@ describe('RateLimitsEditor.vue', () => {
       'timeframe': '60',
       'include': ['blocklist'],
       'exclude': ['allowlist'],
-      'key': [{'attrs': 'securitypolicyid'}, {'attrs': 'securitypolicyentryid'}, {'attrs': 'curiesession'}],
+      'key': [{'attrs': 'securitypolicyid'}, {'attrs': 'securitypolicyentryid'}, {'attrs': 'session'}],
       'pairwith': {'self': 'self'},
     }]
     securityPoliciesDocs = [
@@ -197,10 +197,10 @@ describe('RateLimitsEditor.vue', () => {
     })
 
     test('should have response action selection with correct data', () => {
-      const wantedAction = rateLimitsDocs[0].thresholds[0].action.toString()
+      const wantedCustomResponse = rateLimitsDocs[0].thresholds[0].action.toString()
       const thresholdActionSelection = wrapper.find('.threshold-action-selection')
-      const selectedAction = (thresholdActionSelection.find('option:checked').element as HTMLOptionElement).value
-      expect(selectedAction).toEqual(wantedAction)
+      const selectedCustomResponse = (thresholdActionSelection.find('option:checked').element as HTMLOptionElement).value
+      expect(selectedCustomResponse).toEqual(wantedCustomResponse)
     })
 
     test('should have correct include data in table', () => {
@@ -307,12 +307,12 @@ describe('RateLimitsEditor.vue', () => {
       const addThresholdButton = wrapper.find('.add-threshold-button')
       await addThresholdButton.trigger('click')
       const wantedLimit = 0
-      const wantedAction = 'default'
+      const wantedCustomResponse = 'default'
       const actualLimit = wrapper.vm.localDoc.thresholds[1].limit
-      const actualAction = wrapper.vm.localDoc.thresholds[1].action
+      const actualCustomResponse = wrapper.vm.localDoc.thresholds[1].action
       expect(wrapper.vm.localDoc.thresholds.length).toEqual(2)
       expect(actualLimit).toEqual(wantedLimit)
-      expect(actualAction).toEqual(wantedAction)
+      expect(actualCustomResponse).toEqual(wantedCustomResponse)
     })
 
     test('should remove threshold when remove event occurs', async () => {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,18 +6,18 @@ import PublishChanges from '@/views/Publish.vue'
 import VersionControl from '@/views/VersionControl.vue'
 import DocumentList from '@/views/DocumentList.vue'
 import QuarantinedList from '@/components/QuarantinedList.vue'
-import RoutingProfileList from '@/views/RoutingProfileList.vue'
-import RoutingProfileEditor from '@/doc-editors/RoutingProfileEditor.vue'
-import MobileSDKList from '@/views/MobileSDKList.vue'
-import MobileSDKEditor from '@/doc-editors/MobileSDKEditor.vue'
-import ProxyTemplateList from '@/views/ProxyTemplateList.vue'
-import ProxyTemplateEditor from '@/doc-editors/ProxyTemplateEditor.vue'
-import WebProxyList from '@/views/WebProxyList.vue'
-import WebProxyEditor from '@/doc-editors/WebProxyEditor.vue'
-import BackendServiceList from '@/views/BackendServiceList.vue'
-import BackendServiceEditor from '@/doc-editors/BackendServiceEditor.vue'
+import RoutingProfileList from '@/views/RoutingProfilesList.vue'
+import RoutingProfileEditor from '@/doc-editors/RoutingProfilesEditor.vue'
+import MobileSDKList from '@/views/MobileSDKsList.vue'
+import MobileSDKEditor from '@/doc-editors/MobileSDKsEditor.vue'
+import ConfigTemplateList from '@/views/ConfigTemplatesList.vue'
+import ConfigTemplateEditor from '@/doc-editors/ConfigTemplatesEditor.vue'
+import ServerGroupsList from '@/views/ServerGroupsList.vue'
+import ServerGroupsEditor from '@/doc-editors/ServerGroupsEditor.vue'
+import BackendServiceList from '@/views/BackendServicesList.vue'
+import BackendServiceEditor from '@/doc-editors/BackendServicesEditor.vue'
 import HelpAndSupport from '@/views/HelpAndSupport.vue'
-import DashboardDisplay from '@/views/Dashboard.vue'
+import DashboardDisplay from '@/views/Dashboards.vue'
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -32,21 +32,21 @@ const routes: Array<RouteRecordRaw> = [
         redirect: '/dashboard',
         children: [
           {
-            path: 'web-proxy',
-            name: 'WebProxy',
+            path: 'server-groups',
+            name: 'ServerGroups',
             redirect: (route) => {
-              return `/${route.params.branch}/web-proxy/list`
+              return `/${route.params.branch}/server-groups/list`
             },
             children: [
               {
                 path: 'list',
-                name: 'WebProxy/list',
-                component: WebProxyList,
+                name: 'ServerGroups/list',
+                component: ServerGroupsList,
               },
               {
                 path: 'config/:doc_id',
-                name: 'WebProxy/config',
-                component: WebProxyEditor,
+                name: 'ServerGroups/config',
+                component: ServerGroupsEditor,
               },
             ],
           },
@@ -89,21 +89,21 @@ const routes: Array<RouteRecordRaw> = [
             ],
           },
           {
-            path: 'proxy-templates',
-            name: 'ProxyTemplates',
+            path: 'config-templates',
+            name: 'ConfigTemplates',
             redirect: (route) => {
-              return `/${route.params.branch}/proxy-templates/list`
+              return `/${route.params.branch}/config-templates/list`
             },
             children: [
               {
                 path: 'list',
-                name: 'ProxyTemplates/list',
-                component: ProxyTemplateList,
+                name: 'ConfigTemplates/list',
+                component: ConfigTemplateList,
               },
               {
                 path: 'config/:doc_id',
-                name: 'ProxyTemplates/config',
-                component: ProxyTemplateEditor,
+                name: 'ConfigTemplates/config',
+                component: ConfigTemplateEditor,
               },
             ],
           },

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -44,12 +44,14 @@ declare module CuriefenseClient {
     limit_ids: string[]
   }
 
-  type GlobalFilterSectionEntry = [Category, string | string[], string?]
+  type GlobalFilterRuleEntry = [Category, string | string[], string]
 
-  type GlobalFilterSection = {
-    entries: GlobalFilterSectionEntry[]
+  type GlobalFilterRuleSection = {
     relation: Relation
+    entries: GlobalFilterRule[]
   }
+
+  type GlobalFilterRule = GlobalFilterRuleSection | GlobalFilterRuleEntry
 
   type LimitOptionType = {
     [key: string]: string
@@ -80,11 +82,11 @@ declare module CuriefenseClient {
 
   type NamesRegexType = 'names' | 'regex'
 
-  type CloudFunctionsPhaseType = 'request1' | 'response0'
+  type EdgeFunctionsPhaseType = 'request' | 'response'
 
   type Document =
     BasicDocument
-    & (ACLProfile | CloudFunction | ContentFilterProfile | ContentFilterRule | CustomResponse |
+    & (ACLProfile | EdgeFunction | ContentFilterProfile | ContentFilterRule | CustomResponse |
       DynamicRule | FlowControlPolicy | GlobalFilter | RateLimit | SecurityPolicy)
 
   type DocumentType =
@@ -159,10 +161,7 @@ declare module CuriefenseClient {
     active: boolean
     tags: string[]
     action: string
-    rule: {
-      relation: Relation
-      entries: GlobalFilterSection[]
-    }
+    rule: GlobalFilterRuleSection
   }
 
   type SecurityPolicy = {
@@ -174,12 +173,12 @@ declare module CuriefenseClient {
     map: SecurityPolicyEntryMatch[]
   }
 
-  type CloudFunction = {
+  type EdgeFunction = {
     id: string
     name: string
     description: string
     code: string
-    phase: CloudFunctionsPhaseType
+    phase: EdgeFunctionsPhaseType
   }
 
   type DynamicRule = {
@@ -200,6 +199,7 @@ declare module CuriefenseClient {
     id: string
     name: string
     global: boolean
+    active: boolean
     description: string
     thresholds: ThresholdActionPair[]
     key: LimitOptionType[]
@@ -341,7 +341,7 @@ declare module CuriefenseClient {
     support_legacy_sdk: boolean
   }
 
-  type ProxyTemplate = {
+  type ConfigTemplate = {
     name: string
     id: string
     description: string
@@ -373,7 +373,7 @@ declare module CuriefenseClient {
     server_names: string[]
     security_policy: SecurityPolicy['id']
     routing_profile: RoutingProfile['id']
-    proxy_template: ProxyTemplate['id']
+    proxy_template: ConfigTemplate['id']
     mobile_sdk: MobileSDK['id']
     ssl_certificate?: string
   }

--- a/src/views/BackendServicesList.vue
+++ b/src/views/BackendServicesList.vue
@@ -2,16 +2,19 @@
   <div class="card-content">
     <div class="media">
       <div class="media-content">
-        <div class="field is-grouped">
+        <div class="field is-grouped is-pulled-right">
           <p class="control">
             <button class="button is-small download-doc-button"
                     :class="{'is-loading':isDownloadLoading}"
                     @click="downloadDoc()"
                     title="Download document"
                     data-qa="download-document">
-                <span class="icon is-small">
-                    <i class="fas fa-download"></i>
-                </span>
+              <span class="icon is-small">
+                <i class="fas fa-download"></i>
+              </span>
+              <span>
+                Download
+              </span>
             </button>
           </p>
         </div>
@@ -26,15 +29,17 @@
         <div class="card-content">
           <div class="content">
             <rbz-table :columns="columns"
-                       :data="routingProfiles"
+                       :data="backendServices"
                        :show-menu-column="true"
                        :show-filter-button="true"
                        :show-new-button="true"
-                       @new-button-clicked="addNewProfile"
+                       @new-button-clicked="addNewBackendService"
+                       :row-clickable="true"
+                       @row-clicked="editBackendService"
                        :show-row-button="true"
-                       @row-button-clicked="editProfile">
+                       @row-button-clicked="editBackendService">
             </rbz-table>
-            <span class="is-family-monospace has-text-grey-lighter">
+            <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">
                 {{ documentListAPIPath }}
               </span>
           </div>
@@ -54,15 +59,16 @@
 import _ from 'lodash'
 import {defineComponent} from 'vue'
 import RbzTable from '@/components/RbzTable.vue'
-import {ColumnOptions, RoutingProfile} from '@/types'
+import {BackendService, ColumnOptions} from '@/types'
 import DatasetsUtils from '@/assets/DatasetsUtils'
 import RequestsUtils from '@/assets/RequestsUtils'
 import Utils from '@/assets/Utils'
+import backendServicesConsts from '@/assets/backendServicesConsts'
 import {mapStores} from 'pinia'
 import {useBranchesStore} from '@/stores/BranchesStore'
 
 export default defineComponent({
-  name: 'RoutingProfileList',
+  name: 'BackendServiceList',
   components: {
     RbzTable,
   },
@@ -84,33 +90,47 @@ export default defineComponent({
           classes: 'ellipsis',
         },
         {
-          title: 'Paths',
-          fieldNames: ['locations'],
-          displayFunction: (item: RoutingProfile) => {
-            return item.locations.length
+          title: 'Hosts',
+          fieldNames: ['back_hosts'],
+          displayFunction: (item: BackendService) => {
+            return _.map(item.back_hosts, 'host')
           },
           isSortable: true,
           isSearchable: true,
-          classes: 'width-60px white-space-pre',
+          classes: 'width-150px',
         },
         {
-          title: 'Cloud Functions',
-          fieldNames: ['locations'],
-          displayFunction: (item: RoutingProfile) => {
-            return _.sumBy(item.locations, (mapEntry) => {
-              return mapEntry['cloud_functions']?.length || 0
-            })
+          title: 'Transport Protocol',
+          fieldNames: ['transport_mode'],
+          displayFunction: (item: BackendService) => {
+            return backendServicesConsts.transportProtocols.find((protocol) => {
+              return item.transport_mode === protocol.value
+            }).name
           },
           isSortable: true,
           isSearchable: true,
-          classes: 'width-120px white-space-pre',
+          classes: 'width-150px',
+        },
+        {
+          title: 'Stickiness Model',
+          fieldNames: ['sticky'],
+          displayFunction: (item: BackendService) => {
+            return backendServicesConsts.stickinessModels.find((protocol) => {
+              return item.sticky === protocol.value
+            }).name
+          },
+          isSortable: true,
+          isSearchable: true,
+          classes: 'width-120px',
         },
       ] as ColumnOptions[],
       isNewLoading: false,
       titles: DatasetsUtils.titles,
-      routingProfiles: [] as RoutingProfile[],
+      backendServices: [],
+
       loadingDocCounter: 0,
       isDownloadLoading: false,
+
       apiRoot: RequestsUtils.reblazeAPIRoot,
       apiVersion: RequestsUtils.reblazeAPIVersion,
     }
@@ -119,8 +139,8 @@ export default defineComponent({
   watch: {
     selectedBranch: {
       handler: function(val, oldVal) {
-        if ((this.$route.name as string).includes('RoutingProfiles/list') && val && val !== oldVal) {
-          this.loadProfiles()
+        if ((this.$route.name as string).includes('BackendServices/list') && val && val !== oldVal) {
+          this.loadBackendServices()
         }
       },
       immediate: true,
@@ -130,7 +150,7 @@ export default defineComponent({
   computed: {
     documentListAPIPath(): string {
       const apiPrefix = `${this.apiRoot}/${this.apiVersion}`
-      return `${apiPrefix}/reblaze/configs/${this.selectedBranch}/d/routing-profiles/`
+      return `${apiPrefix}/reblaze/configs/${this.selectedBranch}/d/backends/`
     },
 
     selectedBranch(): string {
@@ -149,44 +169,44 @@ export default defineComponent({
       }
     },
 
-    newProfile(): RoutingProfile {
-      const factory = DatasetsUtils.newOperationEntryFactory['routing-profiles']
+    newBackendService(): BackendService {
+      const factory = DatasetsUtils.newOperationEntryFactory['backends']
       return factory && factory()
     },
 
-    editProfile(id: string) {
-      this.$router.push(`/${this.selectedBranch}/routing-profiles/config/${id}`)
+    editBackendService(id: string) {
+      this.$router.push(`/${this.selectedBranch}/backend-services/config/${id}`)
     },
 
-    async addNewProfile() {
+    async addNewBackendService() {
       this.isNewLoading = true
-      const profileToAdd = this.newProfile()
-      const routingProfileText = this.titles['routing-profiles-singular']
-      const successMessage = `New ${routingProfileText} was created.`
-      const failureMessage = `Failed while attempting to create the new ${routingProfileText}.`
-      const url = `configs/${this.selectedBranch}/d/routing-profiles/e/${profileToAdd.id}`
-      const data = profileToAdd
+      const backendServiceToAdd = this.newBackendService()
+      const backendServiceText = this.titles['backends-singular']
+      const successMessage = `New ${backendServiceText} was created.`
+      const failureMessage = `Failed while attempting to create the new ${backendServiceText}.`
+      const url = `configs/${this.selectedBranch}/d/backends/e/${backendServiceToAdd.id}`
+      const data = backendServiceToAdd
       await RequestsUtils.sendReblazeRequest({methodName: 'POST', url, data, successMessage, failureMessage})
-      this.editProfile(profileToAdd.id)
+      this.editBackendService(backendServiceToAdd.id)
       this.isNewLoading = false
     },
 
     downloadDoc() {
       if (!this.isDownloadLoading) {
-        Utils.downloadFile('routing-profiles', 'json', this.routingProfiles)
+        Utils.downloadFile('backends', 'json', this.backendServices)
       }
     },
 
-    async loadProfiles() {
-      const url = `configs/${this.selectedBranch}/d/routing-profiles/`
+    async loadBackendServices() {
+      const url = `configs/${this.selectedBranch}/d/backends/`
       const response = await RequestsUtils.sendReblazeRequest({methodName: 'GET', url})
-      this.routingProfiles = response?.data
+      this.backendServices = response?.data
     },
 
     async switchBranch() {
       this.setLoadingDocStatus(true)
       Utils.toast(`Switched to branch '${this.selectedBranch}'.`, 'is-info')
-      await this.loadProfiles()
+      await this.loadBackendServices()
       this.setLoadingDocStatus(false)
     },
   },

--- a/src/views/Dashboards.vue
+++ b/src/views/Dashboards.vue
@@ -2,50 +2,52 @@
   <div class="card-content">
     <div class="media">
       <div class="media-content">
-        <div class="columns">
-          <div class="column">
+        <div class="field is-grouped">
+          <div class="control search-wrapper">
             <input class="input is-small is-fullwidth filter-input"
                    placeholder="Filters, comma separated. Available filters: `proxy`, `appid`, and `profile`."
                    v-model="searchFilter"/>
           </div>
-          <div class="column is-narrow">
-            <div class="field is-grouped is-pulled-right">
-              <p class="control">
-                <Datepicker v-model="date"
-                            range
-                            utc
-                            enableSeconds
-                            format="yyyy-MM-dd HH:mm"
-                            inputClassName="input is-small is-size-7 width-260px date-picker-input"
-                            :monthChangeOnScroll="false"
-                            :clearable="false"
-                            :presetRanges="presetRanges"
-                            @open="loadPresetRanges">
-                </Datepicker>
-              </p>
-              <p class="control">
-                <button class="button is-small search-button"
-                        :class="{'is-loading': isSearchLoading}"
-                        @click="loadData()"
-                        title="Search"
-                        data-qa="search-button">
-                    <span class="icon is-small">
-                      <i class="fas fa-search"></i>
-                    </span>
-                </button>
-              </p>
-              <p class="control">
-                <button class="button is-small clear-search-button"
-                        @click="clearSearch()"
-                        title="Clear filter"
-                        data-qa="clear-search-button">
-                    <span class="icon is-small">
-                      <i class="fas fa-times"></i>
-                    </span>
-                </button>
-              </p>
-            </div>
-          </div>
+          <p class="control">
+            <Datepicker v-model="date"
+                        range
+                        utc
+                        enableSeconds
+                        format="yyyy-MM-dd HH:mm"
+                        inputClassName="input is-small is-size-7 width-260px date-picker-input"
+                        :monthChangeOnScroll="false"
+                        :clearable="false"
+                        :presetRanges="presetRanges"
+                        @open="loadPresetRanges">
+            </Datepicker>
+          </p>
+          <p class="control">
+            <button class="button is-small search-button"
+                    :class="{'is-loading': isSearchLoading}"
+                    @click="loadData()"
+                    title="Search"
+                    data-qa="search-button">
+              <span class="icon is-small">
+                <i class="fas fa-search"></i>
+              </span>
+              <span>
+                Search
+              </span>
+            </button>
+          </p>
+          <p class="control">
+            <button class="button is-small clear-search-button"
+                    @click="clearSearch()"
+                    title="Clear filter"
+                    data-qa="clear-search-button">
+              <span class="icon is-small">
+                <i class="fas fa-times"></i>
+              </span>
+              <span>
+                Clear
+              </span>
+            </button>
+          </p>
         </div>
       </div>
     </div>
@@ -70,8 +72,16 @@
         </div>
       </div>
     </div>
-    <div v-if="!isSearchLoading && !data?.length">
-      No results found
+    <div v-if="!data?.length"
+         class="has-text-centered is-fullwidth">
+      <div v-if="isSearchLoading">
+        <button class="button is-outlined is-text is-small is-loading dashboard-loading">
+          Loading
+        </button>
+      </div>
+      <div v-else>
+        Your search did not match any data
+      </div>
     </div>
     <div v-show="dashboards[activeDashboardIndex]?.useDashboard === 'default'">
       <rbz-dashboard-default :data="data"
@@ -242,6 +252,11 @@ export default defineComponent({
 </script>
 <style lang="scss">
 @import 'node_modules/@vuepic/vue-datepicker/src/VueDatePicker/style/main';
+
+.search-wrapper {
+  /* Magic number 450x - width of datepicker, search, and clear buttons */
+  width: calc(100% - 450px);
+}
 
 .date-picker-input {
   padding-left: 33px;

--- a/src/views/DocumentEditor.vue
+++ b/src/views/DocumentEditor.vue
@@ -10,28 +10,14 @@
                         @click="redirectToList()"
                         title="Return to list"
                         data-qa="redirect-to-list">
-                    <span class="icon is-small">
-                      <i class="fas fa-arrow-left"></i>
-                    </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-arrow-left"></i>
+                  </span>
+                  <span>
+                    Back To List
+                  </span>
                 </button>
               </p>
-              <p class="control">
-                <button class="button is-small download-doc-button"
-                        :class="{'is-loading': isDownloadLoading}"
-                        :disabled="!selectedDoc"
-                        @click="downloadDoc()"
-                        title="Download document"
-                        data-qa="download-document">
-                    <span class="icon is-small">
-                      <i class="fas fa-download"></i>
-                    </span>
-                </button>
-              </p>
-            </div>
-          </div>
-
-          <div class="column">
-            <div class="field is-grouped is-pulled-right">
               <div class="control"
                    v-if="docIdNames.length">
                 <div class="select is-small">
@@ -48,6 +34,26 @@
                   </select>
                 </div>
               </div>
+            </div>
+          </div>
+
+          <div class="column">
+            <div class="field is-grouped is-pulled-right">
+              <p class="control">
+                <button class="button is-small new-document-button"
+                        :class="{'is-loading': isNewLoading}"
+                        @click="addNewDoc()"
+                        title="Add new document"
+                        :disabled="!selectedBranch || !selectedDocType"
+                        data-qa="add-new-document">
+                  <span class="icon is-small">
+                    <i class="fas fa-plus"></i>
+                  </span>
+                  <span>
+                    New
+                  </span>
+                </button>
+              </p>
 
               <p class="control">
                 <button class="button is-small fork-document-button"
@@ -56,22 +62,28 @@
                         title="Duplicate document"
                         :disabled="!selectedDoc || dynamicRuleManaged"
                         data-qa="duplicate-document">
-                    <span class="icon is-small">
-                      <i class="fas fa-clone"></i>
-                    </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-clone"></i>
+                  </span>
+                  <span>
+                    Duplicate
+                  </span>
                 </button>
               </p>
 
               <p class="control">
-                <button class="button is-small new-document-button"
-                        :class="{'is-loading': isNewLoading}"
-                        @click="addNewDoc()"
-                        title="Add new document"
-                        :disabled="!selectedBranch || !selectedDocType"
-                        data-qa="add-new-document">
-                    <span class="icon is-small">
-                      <i class="fas fa-plus"></i>
-                    </span>
+                <button class="button is-small download-doc-button"
+                        :class="{'is-loading': isDownloadLoading}"
+                        :disabled="!selectedDoc"
+                        @click="downloadDoc()"
+                        title="Download document"
+                        data-qa="download-document">
+                  <span class="icon is-small">
+                    <i class="fas fa-download"></i>
+                  </span>
+                  <span>
+                    Download
+                  </span>
                 </button>
               </p>
 
@@ -82,9 +94,12 @@
                         title="Save changes"
                         :disabled="isDocumentInvalid || !selectedDoc || dynamicRuleManaged"
                         data-qa="save-changes">
-                    <span class="icon is-small">
-                      <i class="fas fa-save"></i>
-                    </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-save"></i>
+                  </span>
+                  <span>
+                    Save
+                  </span>
                 </button>
               </p>
 
@@ -95,9 +110,12 @@
                         title="Delete document"
                         :disabled="selectedDocNotDeletable"
                         data-qa="delete-document">
-                    <span class="icon is-small">
-                      <i class="fas fa-trash"></i>
-                    </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-trash"></i>
+                  </span>
+                  <span>
+                    Delete
+                  </span>
                 </button>
               </p>
 
@@ -139,7 +157,7 @@
       </div>
       <div v-else
            class="no-data-message">
-        No data found!
+        No data found
         <div>
           <!--display correct message by priority (Document type -> Document)-->
           <span v-if="!Object.keys(componentsMap).includes(selectedDocType)">
@@ -164,15 +182,15 @@ import DatasetsUtils from '@/assets/DatasetsUtils'
 import RequestsUtils from '@/assets/RequestsUtils'
 import Utils from '@/assets/Utils'
 import ACLEditor from '@/doc-editors/ACLEditor.vue'
-import ContentFilterEditor from '@/doc-editors/ContentFilterProfileEditor.vue'
+import ContentFilterEditor from '@/doc-editors/ContentFilterProfilesEditor.vue'
 import ContentFilterRulesEditor from '@/doc-editors/ContentFilterRulesEditor.vue'
 import SecurityPoliciesEditor from '@/doc-editors/SecurityPoliciesEditor.vue'
-import RateLimitsEditor from '@/doc-editors/RateLimitsEditor.vue'
-import CloudFunctionsEditor from '@/doc-editors/CloudFunctionsEditor.vue'
+import RateLimitsEditor from '@/doc-editors/RateLimitRulesEditor.vue'
+import EdgeFunctionsEditor from '@/doc-editors/EdgeFunctionsEditor.vue'
 import DynamicRulesEditor from '@/doc-editors/DynamicRulesEditor.vue'
-import GlobalFilterListEditor from '@/doc-editors/GlobalFilterListEditor.vue'
-import FlowControlPolicyEditor from '@/doc-editors/FlowControlPolicyEditor.vue'
-import CustomResponseEditor from '@/doc-editors/CustomResponseEditor.vue'
+import GlobalFilterListEditor from '@/doc-editors/GlobalFiltersEditor.vue'
+import FlowControlPolicyEditor from '@/doc-editors/FlowControlPoliciesEditor.vue'
+import CustomResponseEditor from '@/doc-editors/CustomResponsesEditor.vue'
 import GitHistory from '@/components/GitHistory.vue'
 import {mdiSourceBranch, mdiSourceCommit} from '@mdi/js'
 import {defineComponent, shallowRef} from 'vue'
@@ -182,14 +200,14 @@ import {mapStores} from 'pinia'
 import {useBranchesStore} from '@/stores/BranchesStore'
 
 export default defineComponent({
-  name: 'DocumentEditor',
+  name: 'DocumentEditor2',
   props: {},
   components: {
     GitHistory,
   },
   data() {
     const reblazeComponentsMap = {
-      'cloud-functions': shallowRef({component: CloudFunctionsEditor}),
+      'cloud-functions': shallowRef({component: EdgeFunctionsEditor}),
       'dynamic-rules': shallowRef({component: DynamicRulesEditor}),
     }
     return {
@@ -209,7 +227,7 @@ export default defineComponent({
       referencedIDsACL: [],
       referencedIDsContentFilter: [],
       referencedIDsLimits: [],
-      referencedIDsCloudFunctions: [],
+      referencedIDsEdgeFunctions: [],
       referencedIDsDynamicRules: [],
 
       selectedDocType: null as DocumentType,
@@ -338,7 +356,7 @@ export default defineComponent({
         return this.referencedIDsLimits.includes(this.selectedDocID)
       }
       if (this.selectedDocType === 'cloud-functions') {
-        return this.referencedIDsCloudFunctions.includes(this.selectedDocID)
+        return this.referencedIDsEdgeFunctions.includes(this.selectedDocID)
       }
       if (this.selectedDocType === 'dynamic-rules') {
         return this.referencedIDsDynamicRules.includes(this.selectedDocID)
@@ -504,7 +522,7 @@ export default defineComponent({
 
     downloadDoc() {
       if (!this.isDownloadLoading) {
-        Utils.downloadFile(this.selectedDocType, 'json', this.docs)
+        Utils.downloadFile(this.titles[`${this.selectedDocType}-singular`], 'json', this.selectedDoc)
       }
     },
 
@@ -546,19 +564,17 @@ export default defineComponent({
         failureMessage = `Failed while attempting to create the new ${docTypeText}.`
       }
       if (this.selectedDocType === 'dynamic-rules') {
+        let docMatchingGlobalFilter
         if (this.isForkLoading) {
-          const docMatchingGlobalFilter = this.duplicatedDocMatchingGlobalFilter
-          docMatchingGlobalFilter.id = `dr_${this.selectedDocID}`
-          docMatchingGlobalFilter.active = (this.selectedDoc as DynamicRule).active
-          docMatchingGlobalFilter.name = 'Global Filter for Dynamic Rule ' + this.selectedDocID
-          this.selectedDocMatchingGlobalFilter = docMatchingGlobalFilter
+          docMatchingGlobalFilter = this.duplicatedDocMatchingGlobalFilter
         } else {
-          const docMatchingGlobalFilter = DatasetsUtils.newDocEntryFactory['globalfilters']() as GlobalFilter
-          docMatchingGlobalFilter.id = `dr_${this.selectedDocID}`
-          docMatchingGlobalFilter.active = (this.selectedDoc as DynamicRule).active
-          docMatchingGlobalFilter.name = 'Global Filter for Dynamic Rule ' + this.selectedDocID
-          this.selectedDocMatchingGlobalFilter = docMatchingGlobalFilter
+          docMatchingGlobalFilter = DatasetsUtils.newDocEntryFactory['globalfilters']() as GlobalFilter
         }
+        docMatchingGlobalFilter.id = `dr_${this.selectedDocID}`
+        docMatchingGlobalFilter.active = (this.selectedDoc as DynamicRule).active
+        docMatchingGlobalFilter.name = 'Global Filter for Dynamic Rule ' + this.selectedDocID
+        docMatchingGlobalFilter.action = 'action-dynamic-rule-block'
+        this.selectedDocMatchingGlobalFilter = docMatchingGlobalFilter
       }
       await this.saveChanges('POST', successMessage, failureMessage)
 
@@ -657,7 +673,7 @@ export default defineComponent({
       const referencedACL: string[] = []
       const referencedContentFilter: string[] = []
       const referencedLimit: string[] = []
-      const referencedCloudFunctions: string[] = []
+      const referencedEdgeFunctions: string[] = []
       _.forEach(docs, (doc) => {
         _.forEach(doc.map, (mapEntry) => {
           referencedACL.push(mapEntry['acl_profile'])
@@ -668,7 +684,7 @@ export default defineComponent({
       this.referencedIDsACL = _.uniq(referencedACL)
       this.referencedIDsContentFilter = _.uniq(referencedContentFilter)
       this.referencedIDsLimits = _.uniq(_.flatten(referencedLimit))
-      this.referencedIDsCloudFunctions = _.uniq(_.flatten(referencedCloudFunctions))
+      this.referencedIDsEdgeFunctions = _.uniq(_.flatten(referencedEdgeFunctions))
     },
 
     restoreGitVersion() {

--- a/src/views/DocumentList.vue
+++ b/src/views/DocumentList.vue
@@ -2,16 +2,19 @@
   <div class="card-content">
     <div class="media">
       <div class="media-content">
-        <div class="field is-grouped">
+        <div class="field is-grouped is-pulled-right">
           <p class="control">
             <button class="button is-small download-doc-button"
                     :class="{'is-loading':isDownloadLoading}"
                     @click="downloadDoc()"
                     title="Download document"
                     data-qa="download-document">
-                <span class="icon is-small">
-                    <i class="fas fa-download"></i>
-                </span>
+              <span class="icon is-small">
+                <i class="fas fa-download"></i>
+              </span>
+              <span>
+                Download
+              </span>
             </button>
           </p>
         </div>
@@ -22,25 +25,23 @@
 
     <div class="content document-list-wrapper"
          v-show="!loadingDocCounter && selectedBranch && selectedDocType">
-      <div class="card">
-        <div class="card-content">
-          <div class="content">
-            <rbz-table :columns="columns"
-                       :data="docs"
-                       :show-menu-column="true"
-                       :show-filter-button="true"
-                       :show-new-button="true"
-                       @new-button-clicked="addNewDoc"
-                       :show-row-button="true"
-                       :row-button-title="rowButtonTitle"
-                       :row-button-icon="rowButtonIcon"
-                       @row-button-clicked="editDoc">
-            </rbz-table>
-            <span class="is-family-monospace has-text-grey-lighter">
-                {{ documentListAPIPath }}
-              </span>
-          </div>
-        </div>
+      <div class="content">
+        <rbz-table :columns="columns"
+                   :data="docs"
+                   :show-menu-column="true"
+                   :show-filter-button="true"
+                   :show-new-button="true"
+                   @new-button-clicked="addNewDoc"
+                   :row-clickable="true"
+                   @row-clicked="editDoc"
+                   :show-row-button="true"
+                   :row-button-title="rowButtonTitle"
+                   :row-button-icon="rowButtonIcon"
+                   @row-button-clicked="editDoc">
+        </rbz-table>
+        <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">
+          {{ documentListAPIPath }}
+        </span>
       </div>
       <hr/>
       <git-history v-if="!isReblazeDocument"
@@ -58,7 +59,7 @@
       </div>
       <div v-else
            class="no-data-message">
-        No data found!
+        No data found
         <div>
           <span v-if="!Object.keys(componentsMap).includes(selectedDocType)">
             Missing document type. Please check your URL or click a link in the menu to the side
@@ -75,14 +76,14 @@ import DatasetsUtils from '@/assets/DatasetsUtils'
 import RequestsUtils from '@/assets/RequestsUtils'
 import Utils from '@/assets/Utils'
 import ACLEditor from '@/doc-editors/ACLEditor.vue'
-import ContentFilterEditor from '@/doc-editors/ContentFilterProfileEditor.vue'
+import ContentFilterEditor from '@/doc-editors/ContentFilterProfilesEditor.vue'
 import ContentFilterRulesEditor from '@/doc-editors/ContentFilterRulesEditor.vue'
 import SecurityPoliciesEditor from '@/doc-editors/SecurityPoliciesEditor.vue'
-import RateLimitsEditor from '@/doc-editors/RateLimitsEditor.vue'
-import GlobalFilterListEditor from '@/doc-editors/GlobalFilterListEditor.vue'
-import FlowControlPolicyEditor from '@/doc-editors/FlowControlPolicyEditor.vue'
-import CloudFunctionsEditor from '@/doc-editors/CloudFunctionsEditor.vue'
-import CustomResponseEditor from '@/doc-editors/CustomResponseEditor.vue'
+import RateLimitsEditor from '@/doc-editors/RateLimitRulesEditor.vue'
+import GlobalFilterListEditor from '@/doc-editors/GlobalFiltersEditor.vue'
+import FlowControlPolicyEditor from '@/doc-editors/FlowControlPoliciesEditor.vue'
+import EdgeFunctionsEditor from '@/doc-editors/EdgeFunctionsEditor.vue'
+import CustomResponseEditor from '@/doc-editors/CustomResponsesEditor.vue'
 import DynamicRulesEditor from '@/doc-editors/DynamicRulesEditor.vue'
 import GitHistory from '@/components/GitHistory.vue'
 import {defineComponent, shallowRef} from 'vue'
@@ -122,7 +123,7 @@ export default defineComponent({
   },
   data() {
     const reblazeComponentsMap = {
-      'cloud-functions': shallowRef({component: CloudFunctionsEditor}),
+      'cloud-functions': shallowRef({component: EdgeFunctionsEditor}),
       'dynamic-rules': shallowRef({component: DynamicRulesEditor}),
     }
     return {

--- a/src/views/MobileSDKsList.vue
+++ b/src/views/MobileSDKsList.vue
@@ -2,16 +2,19 @@
   <div class="card-content">
     <div class="media">
       <div class="media-content">
-        <div class="field is-grouped">
+        <div class="field is-grouped is-pulled-right">
           <p class="control">
             <button class="button is-small download-doc-button"
                     :class="{'is-loading':isDownloadLoading}"
                     @click="downloadDoc()"
                     title="Download document"
                     data-qa="download-document">
-                <span class="icon is-small">
-                    <i class="fas fa-download"></i>
-                </span>
+              <span class="icon is-small">
+                <i class="fas fa-download"></i>
+              </span>
+              <span>
+                Download
+              </span>
             </button>
           </p>
         </div>
@@ -26,15 +29,17 @@
         <div class="card-content">
           <div class="content">
             <rbz-table :columns="columns"
-                       :data="backendServices"
+                       :data="mobileSDKs"
                        :show-menu-column="true"
                        :show-filter-button="true"
                        :show-new-button="true"
-                       @new-button-clicked="addNewBackendService"
+                       @new-button-clicked="addNewSDK"
+                       :row-clickable="true"
+                       @row-clicked="editMobileSDK"
                        :show-row-button="true"
-                       @row-button-clicked="editBackendService">
+                       @row-button-clicked="editMobileSDK">
             </rbz-table>
-            <span class="is-family-monospace has-text-grey-lighter">
+            <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">
                 {{ documentListAPIPath }}
               </span>
           </div>
@@ -51,19 +56,17 @@
   </div>
 </template>
 <script lang="ts">
-import _ from 'lodash'
 import {defineComponent} from 'vue'
 import RbzTable from '@/components/RbzTable.vue'
-import {BackendService, ColumnOptions} from '@/types'
+import {ColumnOptions, MobileSDK} from '@/types'
 import DatasetsUtils from '@/assets/DatasetsUtils'
 import RequestsUtils from '@/assets/RequestsUtils'
 import Utils from '@/assets/Utils'
-import backendServicesConsts from '@/assets/backendServicesConsts'
 import {mapStores} from 'pinia'
 import {useBranchesStore} from '@/stores/BranchesStore'
 
 export default defineComponent({
-  name: 'BackendServiceList',
+  name: 'MobileSDKList',
   components: {
     RbzTable,
   },
@@ -85,47 +88,28 @@ export default defineComponent({
           classes: 'ellipsis',
         },
         {
-          title: 'Hosts',
-          fieldNames: ['back_hosts'],
-          displayFunction: (item: BackendService) => {
-            return _.map(item.back_hosts, 'host')
+          title: 'Grace Period',
+          fieldNames: ['grace'],
+          displayFunction: (item: MobileSDK) => {
+            return `${item.grace} seconds`
           },
+          isSortable: true,
+          isSearchable: true,
+          classes: 'width-100px',
+        },
+        {
+          title: 'Token Header Name',
+          fieldNames: ['uid_header'],
           isSortable: true,
           isSearchable: true,
           classes: 'width-150px',
-        },
-        {
-          title: 'Transport Protocol',
-          fieldNames: ['transport_mode'],
-          displayFunction: (item: BackendService) => {
-            return backendServicesConsts.transportProtocols.find((protocol) => {
-              return item.transport_mode === protocol.value
-            }).name
-          },
-          isSortable: true,
-          isSearchable: true,
-          classes: 'width-150px',
-        },
-        {
-          title: 'Stickiness Model',
-          fieldNames: ['sticky'],
-          displayFunction: (item: BackendService) => {
-            return backendServicesConsts.stickinessModels.find((protocol) => {
-              return item.sticky === protocol.value
-            }).name
-          },
-          isSortable: true,
-          isSearchable: true,
-          classes: 'width-120px',
         },
       ] as ColumnOptions[],
       isNewLoading: false,
       titles: DatasetsUtils.titles,
-      backendServices: [],
-
+      mobileSDKs: [],
       loadingDocCounter: 0,
       isDownloadLoading: false,
-
       apiRoot: RequestsUtils.reblazeAPIRoot,
       apiVersion: RequestsUtils.reblazeAPIVersion,
     }
@@ -134,8 +118,8 @@ export default defineComponent({
   watch: {
     selectedBranch: {
       handler: function(val, oldVal) {
-        if ((this.$route.name as string).includes('BackendServices/list') && val && val !== oldVal) {
-          this.loadBackendServices()
+        if ((this.$route.name as string).includes('MobileSDKs/list') && val && val !== oldVal) {
+          this.loadMobileSDKs()
         }
       },
       immediate: true,
@@ -145,7 +129,7 @@ export default defineComponent({
   computed: {
     documentListAPIPath(): string {
       const apiPrefix = `${this.apiRoot}/${this.apiVersion}`
-      return `${apiPrefix}/reblaze/configs/${this.selectedBranch}/d/backends/`
+      return `${apiPrefix}/reblaze/configs/${this.selectedBranch}/d/mobile-sdks/`
     },
 
     selectedBranch(): string {
@@ -164,44 +148,50 @@ export default defineComponent({
       }
     },
 
-    newBackendService(): BackendService {
-      const factory = DatasetsUtils.newOperationEntryFactory['backends']
+    newMobileSDK(): MobileSDK {
+      const factory = DatasetsUtils.newOperationEntryFactory['mobile-sdks']
       return factory && factory()
     },
 
-    editBackendService(id: string) {
-      this.$router.push(`/${this.selectedBranch}/backend-services/config/${id}`)
+    editMobileSDK(id: string) {
+      this.$router.push(`/${this.selectedBranch}/mobile-sdks/config/${id}`)
     },
 
-    async addNewBackendService() {
+    async addNewSDK() {
       this.isNewLoading = true
-      const backendServiceToAdd = this.newBackendService()
-      const backendServiceText = this.titles['backends-singular']
-      const successMessage = `New ${backendServiceText} was created.`
-      const failureMessage = `Failed while attempting to create the new ${backendServiceText}.`
-      const url = `configs/${this.selectedBranch}/d/backends/e/${backendServiceToAdd.id}`
-      const data = backendServiceToAdd
-      await RequestsUtils.sendReblazeRequest({methodName: 'POST', url, data, successMessage, failureMessage})
-      this.editBackendService(backendServiceToAdd.id)
+      const mobileSDKToAdd = this.newMobileSDK()
+      const mobileSDKText = this.titles['mobile-sdks-singular']
+      const successMessage = `New ${mobileSDKText} was created.`
+      const failureMessage = `Failed while attempting to create the new ${mobileSDKText}.`
+      const url = `configs/${this.selectedBranch}/d/mobile-sdks/e/${mobileSDKToAdd.id}/`
+      const data = mobileSDKToAdd
+      await RequestsUtils.sendReblazeRequest({
+        methodName: 'POST',
+        url,
+        data,
+        successMessage,
+        failureMessage,
+      })
+      this.editMobileSDK(mobileSDKToAdd.id)
       this.isNewLoading = false
     },
 
     downloadDoc() {
       if (!this.isDownloadLoading) {
-        Utils.downloadFile('backends', 'json', this.backendServices)
+        Utils.downloadFile('mobile-sdks', 'json', this.mobileSDKs)
       }
     },
 
-    async loadBackendServices() {
-      const url = `configs/${this.selectedBranch}/d/backends/`
+    async loadMobileSDKs() {
+      const url = `configs/${this.selectedBranch}/d/mobile-sdks/`
       const response = await RequestsUtils.sendReblazeRequest({methodName: 'GET', url})
-      this.backendServices = response?.data
+      this.mobileSDKs = response?.data
     },
 
     async switchBranch() {
       this.setLoadingDocStatus(true)
       Utils.toast(`Switched to branch '${this.selectedBranch}'.`, 'is-info')
-      await this.loadBackendServices()
+      await this.loadMobileSDKs()
       this.setLoadingDocStatus(false)
     },
   },

--- a/src/views/ServerGroupsList.vue
+++ b/src/views/ServerGroupsList.vue
@@ -2,16 +2,19 @@
   <div class="card-content">
     <div class="media">
       <div class="media-content">
-        <div class="field is-grouped">
+        <div class="field is-grouped is-pulled-right">
           <p class="control">
             <button class="button is-small download-doc-button"
                     :class="{'is-loading':isDownloadLoading}"
                     @click="downloadDoc()"
                     title="Download document"
                     data-qa="download-document">
-                <span class="icon is-small">
-                    <i class="fas fa-download"></i>
-                </span>
+              <span class="icon is-small">
+                <i class="fas fa-download"></i>
+              </span>
+              <span>
+                Download
+              </span>
             </button>
           </p>
         </div>
@@ -31,10 +34,12 @@
                        :show-filter-button="true"
                        :show-new-button="true"
                        @new-button-clicked="addNewSite"
+                       :row-clickable="true"
+                       @row-clicked="editSite"
                        :show-row-button="true"
                        @row-button-clicked="editSite">
             </rbz-table>
-            <span class="is-family-monospace has-text-grey-lighter">
+            <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">
                 {{ documentListAPIPath }}
               </span>
           </div>
@@ -54,7 +59,7 @@
 import _ from 'lodash'
 import {defineComponent} from 'vue'
 import RbzTable from '@/components/RbzTable.vue'
-import {ColumnOptions, MobileSDK, ProxyTemplate, RoutingProfile, SecurityPolicy, Site} from '@/types'
+import {ColumnOptions, MobileSDK, ConfigTemplate, RoutingProfile, SecurityPolicy, Site} from '@/types'
 import DatasetsUtils from '@/assets/DatasetsUtils'
 import RequestsUtils from '@/assets/RequestsUtils'
 import Utils from '@/assets/Utils'
@@ -63,7 +68,7 @@ import {mapStores} from 'pinia'
 import {useBranchesStore} from '@/stores/BranchesStore'
 
 export default defineComponent({
-  name: 'WebProxyList',
+  name: 'ServerGroupsList',
   components: {
     RbzTable,
   },
@@ -111,13 +116,13 @@ export default defineComponent({
           classes: 'width-120px ellipsis',
         },
         {
-          title: 'Proxy Template',
+          title: 'Config Template',
           fieldNames: ['proxy_template'],
           displayFunction: (item: Site) => {
-            const proxyTemplate = _.find(this.proxyTemplatesNames, (proxyTemplate) => {
-              return proxyTemplate[0] === item.proxy_template
+            const configTemplate = _.find(this.configTemplatesNames, (configTemplate) => {
+              return configTemplate[0] === item.proxy_template
             })
-            return proxyTemplate?.[1] || ''
+            return configTemplate?.[1] || ''
           },
           isSortable: true,
           isSearchable: true,
@@ -144,7 +149,7 @@ export default defineComponent({
       isDownloadLoading: false,
       securityPoliciesNames: [] as [SecurityPolicy['id'], SecurityPolicy['name']][],
       routingProfilesNames: [] as [RoutingProfile['id'], RoutingProfile['name']][],
-      proxyTemplatesNames: [] as [ProxyTemplate['id'], ProxyTemplate['name']][],
+      configTemplatesNames: [] as [ConfigTemplate['id'], ConfigTemplate['name']][],
       mobileSDKsNames: [] as [MobileSDK['id'], MobileSDK['name']][],
       apiRoot: RequestsUtils.reblazeAPIRoot,
       apiVersion: RequestsUtils.reblazeAPIVersion,
@@ -154,11 +159,11 @@ export default defineComponent({
   watch: {
     selectedBranch: {
       handler: function(val, oldVal) {
-        if ((this.$route.name as string).includes('WebProxy/list') && val && val !== oldVal) {
+        if ((this.$route.name as string).includes('ServerGroups/list') && val && val !== oldVal) {
           this.loadSites()
           this.loadSecurityPolicies()
           this.loadRoutingProfiles()
-          this.loadProxyTemplates()
+          this.loadConfigTemplates()
           this.loadMobileSDKs()
         }
       },
@@ -194,7 +199,7 @@ export default defineComponent({
     },
 
     editSite(id: string) {
-      this.$router.push(`/${this.selectedBranch}/web-proxy/config/${id}`)
+      this.$router.push(`/${this.selectedBranch}/server-groups/config/${id}`)
     },
 
     async addNewSite() {
@@ -257,13 +262,13 @@ export default defineComponent({
       })
     },
 
-    loadProxyTemplates() {
+    loadConfigTemplates() {
       RequestsUtils.sendReblazeRequest({
         methodName: 'GET',
         url: `configs/${this.selectedBranch}/d/proxy-templates/`,
         config: {headers: {'x-fields': 'id, name'}},
-      }).then((response: AxiosResponse<ProxyTemplate[]>) => {
-        this.proxyTemplatesNames = _.sortBy(_.map(response.data, (entity) => {
+      }).then((response: AxiosResponse<ConfigTemplate[]>) => {
+        this.configTemplatesNames = _.sortBy(_.map(response.data, (entity) => {
           return [entity.id, entity.name]
         }), (e) => {
           return e[1]

--- a/src/views/SystemDBEditor.vue
+++ b/src/views/SystemDBEditor.vue
@@ -215,7 +215,7 @@
                     title="Value"
                     data-qa="value-input"
                     rows="20"
-                    class="is-family-monospace textarea value-input"
+                    class="textarea value-input"
                     v-model="selectedKeyValue">
                   </textarea>
               </div>
@@ -239,7 +239,7 @@
       </div>
       <div v-else
            class="no-data-message">
-        No data found!
+        No data found
         <div>
           <!--display correct message by priority (Namespace -> Key)-->
           <span v-if="!selectedNamespace">

--- a/src/views/VersionControl.vue
+++ b/src/views/VersionControl.vue
@@ -15,6 +15,9 @@
                         <span class="icon is-small">
                           <i class="fas fa-code-branch"></i>
                         </span>
+                        <span>
+                          Fork
+                        </span>
                       </button>
                     </span>
                     <span class="control is-expanded"
@@ -57,9 +60,12 @@
                         @click="downloadBranch()"
                         data-qa="download-branch-btn"
                         title="Download branch">
-                    <span class="icon is-small">
-                      <i class="fas fa-download"></i>
-                    </span>
+                  <span class="icon is-small">
+                    <i class="fas fa-download"></i>
+                  </span>
+                  <span>
+                    Download
+                  </span>
                 </button>
               </p>
 
@@ -68,9 +74,14 @@
                     <span class="control">
                       <button class="button is-small has-text-danger delete-branch-toggle"
                               data-qa="delete-branch-btn"
-                              @click="toggleBranchDelete()">
+                              @click="toggleBranchDelete()"
+                              :disabled="isSelectedBranchProtected"
+                              :title="isSelectedBranchProtected ? 'Protected branch cannot be deleted' : ''">
                         <span class="icon is-small">
                           <i class="fas fa-trash"></i>
+                        </span>
+                        <span>
+                          Delete
                         </span>
                       </button>
                     </span>
@@ -178,6 +189,10 @@ export default defineComponent({
     isSelectedBranchDeleteNameValid(): boolean {
       const newName = this.deleteBranchName.trim()
       return newName === this.selectedBranch
+    },
+
+    isSelectedBranchProtected(): boolean {
+      return ['prod', 'stage'].includes(this.selectedBranch.toLowerCase())
     },
 
     selectedBranch(): string {

--- a/src/views/__tests__/DocumentEditor.spec.ts
+++ b/src/views/__tests__/DocumentEditor.spec.ts
@@ -17,7 +17,7 @@ import {
   GlobalFilter,
   RateLimit,
   SecurityPolicy,
-  CloudFunction,
+  EdgeFunction,
 } from '@/types'
 import {setImmediate, setTimeout} from 'timers'
 import {nextTick} from 'vue'
@@ -40,7 +40,7 @@ describe.skip('DocumentEditor.vue', () => {
   let flowControlPolicyDocs: FlowControlPolicy[]
   let contentFilterDocs: ContentFilterProfile[]
   let rateLimitsDocs: RateLimit[]
-  let cloudFunctionsDocs: CloudFunction[]
+  let edgeFunctionsDocs: EdgeFunction[]
 
   beforeEach((done) => {
     gitData = [
@@ -736,11 +736,11 @@ describe.skip('DocumentEditor.vue', () => {
       'report': [],
       'ignore': [],
     }]
-    cloudFunctionsDocs = [{
+    edgeFunctionsDocs = [{
       'id': 'cf-12345678',
-      'name': 'New Cloud Functions',
+      'name': 'New Edge Functions',
       'key': 'cf12345678',
-      'description': 'New Cloud Functions Documentation',
+      'description': 'New Edge Functions Documentation',
       'code': 'foo = 12345678',
       'phase': 'request0',
     }]
@@ -855,9 +855,9 @@ describe.skip('DocumentEditor.vue', () => {
       }
       if (path === `/reblaze/api/v3/reblaze/config/d/cloud-functions/`) {
         if (config && config.headers && config.headers['x-fields'] === 'id, name') {
-          return Promise.resolve({data: _.map(cloudFunctionsDocs, (i) => _.pick(i, 'id', 'name'))})
+          return Promise.resolve({data: _.map(edgeFunctionsDocs, (i) => _.pick(i, 'id', 'name'))})
         }
-        return Promise.resolve({data: cloudFunctionsDocs[0]})
+        return Promise.resolve({data: edgeFunctionsDocs[0]})
       }
       if (path === '/conf/api/v3/configs/prod/v/') {
         return Promise.resolve({data: gitData[0].logs})

--- a/src/views/documentListConst.ts
+++ b/src/views/documentListConst.ts
@@ -1,6 +1,6 @@
 import {
   ACLProfile,
-  CloudFunction,
+  EdgeFunction,
   ColumnOptionsMap,
   ContentFilterProfile,
   ContentFilterRule,
@@ -50,7 +50,7 @@ export const COLUMN_OPTIONS_MAP: ColumnOptionsMap = {
       classes: 'width-80px',
     },
     {
-      title: 'Action',
+      title: 'Custom Response',
       fieldNames: ['action'],
       isSortable: true,
       isSearchable: true,
@@ -264,6 +264,16 @@ export const COLUMN_OPTIONS_MAP: ColumnOptionsMap = {
       classes: 'ellipsis',
     },
     {
+      title: 'Status Code',
+      fieldNames: ['params'],
+      displayFunction: (item: CustomResponse) => {
+        return item?.params?.status.toString() || ''
+      },
+      isSortable: true,
+      isSearchable: true,
+      classes: 'width-100px white-space-pre ellipsis',
+    },
+    {
       title: 'Tags',
       fieldNames: ['tags'],
       displayFunction: (item: CustomResponse) => {
@@ -405,7 +415,7 @@ export const COLUMN_OPTIONS_MAP: ColumnOptionsMap = {
     {
       title: 'Phase',
       fieldNames: ['phase'],
-      displayFunction: (item: CloudFunction) => {
+      displayFunction: (item: EdgeFunction) => {
         const titles = DatasetsUtils.titles
         return titles[item.phase]
       },


### PR DESCRIPTION
Change loader and no data message for dashboard
Change `curiesession` key option to `session`
Remove `curiesessionids` key option
Change side menu title `Cloud Operations` -> `Proxy Settings`
Change `Web Proxy` to `Server Group`
Change `Proxy Template` to `Config Template`
Change `Cloud Function` to `Edge Function`
Add branch protection (blocking delete) for `prod` and `stage` branches
Change titles and labels of all `Action` fields to `Custom Response`
Change masking of Content Filter Profile `Masking Seed` to not be input type password
Change Publish to first attempt to publish through the saasbackend before publishing through confserver
Add option to open editor through list when row is clicked and not just edit button
Add `Status Code` column to Custom Responses list view
Add `Active` checkbox to Rate Limit editor
Fix default Custom Responses to all documents according to the new bootstrap data
Updated page title to `Reblaze Console` (Hover on tab in the browser)
Change Global Filter Rule to work recursively

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>