### PR TITLE
Global Filter bug fixes

### DIFF
--- a/src/components/RbzTable.vue
+++ b/src/components/RbzTable.vue
@@ -91,7 +91,7 @@
                    :placeholder="col.title"
                    v-model="filter[col.title]"
                    @change="currentPage = 1"/>
-            <span class="icon is-small">
+            <span class="icon is-small is-right">
               <i class="fa fa-filter"
                  aria-hidden="true"></i>
             </span>

--- a/src/doc-editors/GlobalFiltersEditor.vue
+++ b/src/doc-editors/GlobalFiltersEditor.vue
@@ -134,7 +134,7 @@ import RequestsUtils from '@/assets/RequestsUtils'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import EntriesRelationList from '@/components/EntriesRelationList.vue'
 import {defineComponent} from 'vue'
-import {Category, CustomResponse, GlobalFilter, GlobalFilterRule, GlobalFilterRuleEntry} from '@/types'
+import {Category, CustomResponse, GlobalFilter, GlobalFilterRuleEntry} from '@/types'
 import {AxiosResponse} from 'axios'
 import DateTimeUtils from '@/assets/DateTimeUtils'
 
@@ -161,7 +161,7 @@ export default defineComponent({
 
   computed: {
     reblazeManaged(): boolean {
-      return this.localDoc.source === 'reblaze-managed'
+      return this.localDoc.id.startsWith('rbz-')
     },
 
     dynamicRuleManaged(): boolean {
@@ -169,7 +169,7 @@ export default defineComponent({
     },
 
     editable(): boolean {
-      return this.selfManaged && !this.dynamicRuleManaged
+      return this.selfManaged && !this.dynamicRuleManaged && !this.reblazeManaged
     },
 
     selfManaged(): boolean {
@@ -289,14 +289,8 @@ export default defineComponent({
           objectParser(data, entries)
         }
         if (entries.length > 0) {
-          const newSection: GlobalFilterRule = {
-            relation: 'OR',
-            entries: entries,
-          }
           this.localDoc.rule = {
-            'entries': [
-              newSection,
-            ],
+            'entries': entries,
             'relation': 'OR',
           }
           this.localDoc.mdate = (new Date).toISOString()


### PR DESCRIPTION
Change "Clear Section Content" button to be disabled if entries list is empty
Fix Global Filter Rule validation on empty annotation when annotation in value is used
Fix Global Filter Rule validation on empty Header/Cookie/Arg name
Fix Global Filter Rule delete dropdown not closing on outside click
Fix Global Filter `Update now` button to pull list of entries correctly in a single rule level
Change Global Filters starting with ID `rbz-` to be uneditable
Fix RbzTable filter symbol mashing with the placeholder text on filter input

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>