### PR TITLE
Bug fixes and page titles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,8 +23,8 @@
     <noscript>
       <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
-    <section class="section is-fullheight pb-2">
-      <div class="container is-fluid  is-fullheight">
+    <section class="section is-fullheight pb-2 px-3">
+      <div class="container is-fluid is-fullheight">
         <div class="is-fullheight" id="app"></div>
         <!-- built files will be auto injected -->
       </div>

--- a/src/assets/DatasetsUtils.ts
+++ b/src/assets/DatasetsUtils.ts
@@ -16,6 +16,7 @@ import {
   SecurityPolicy,
   Site,
 } from '@/types'
+import _ from 'lodash'
 
 const titles: { [key: string]: string } = {
   'admin': 'Admin',
@@ -52,8 +53,8 @@ const titles: { [key: string]: string } = {
   'aclprofiles-singular': 'ACL Profile',
   'dynamic-rules': 'Dynamic Rules',
   'dynamic-rules-singular': 'Dynamic Rule',
-  'ratelimits': 'Rate Limits',
-  'ratelimits-singular': 'Rate Limit',
+  'ratelimits': 'Rate Limit Rules',
+  'ratelimits-singular': 'Rate Limit Rule',
   'securitypolicies': 'Security Policies',
   'securitypolicies-singular': 'Security Policy',
   'contentfilterprofiles': 'Content Filter Profiles',
@@ -279,9 +280,9 @@ const newDocEntryFactory: { [key: string]: Function } = {
         },
       ],
       'sequence': [
-        {...defaultFlowControlSequenceItem},
+        _.cloneDeep(defaultFlowControlSequenceItem),
         {
-          ...defaultFlowControlSequenceItem,
+          ..._.cloneDeep(defaultFlowControlSequenceItem),
           method: 'POST' as HttpRequestMethods,
         },
       ],
@@ -377,8 +378,12 @@ const newOperationEntryFactory: { [key: string]: Function } = {
       'id': generateUUID2(),
       'name': 'New Mobile SDK ' + generateUUID2(), // TODO: Remove this random uuid once names are no longer unique
       'description': 'New Mobile SDK Description and Remarks',
+      'secret': '',
+      'var_name': '',
       'uid_header': 'authorization',
       'grace': '5',
+      'grace_var_name': '',
+      'validator_type': '',
       'active_config': [
         {
           'active': true,
@@ -387,6 +392,7 @@ const newOperationEntryFactory: { [key: string]: Function } = {
         },
       ],
       'signatures': [],
+      'support_legacy_sdk': false,
     }
   },
 

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -200,6 +200,12 @@ html {
   min-height: 50px;
 }
 
+.height-60px {
+  height: 60px;
+  max-height: 60px;
+  min-height: 60px;
+}
+
 .height-80px {
   height: 80px;
   max-height: 80px;

--- a/src/components/EntriesRelationList.vue
+++ b/src/components/EntriesRelationList.vue
@@ -469,6 +469,7 @@ export default defineComponent({
         this.localRule.entries = [currentSection]
       }
       this.localRule.entries.push(newSection)
+      this.isCollapsed = false
       this.setNewEntryOpen(false)
       this.emitRuleUpdate()
     },
@@ -545,6 +546,8 @@ export default defineComponent({
       if (!value) {
         this.invalidIPs = []
         this.clearError(`${this.newEntryCategory}`)
+      } else {
+        this.isCollapsed = false
       }
       this.newEntryOpen = value
     },

--- a/src/components/HeaderMain.vue
+++ b/src/components/HeaderMain.vue
@@ -3,8 +3,13 @@
     <div class="navbar-brand">
       <a class="navbar-item"
          href="/">
-        <img :src="require('@/assets/logo.png')" class="logo" alt="logo">
+        <img :src="require('@/assets/logo.png')"
+             class="logo"
+             alt="logo">
       </a>
+    </div>
+    <div class="page-title height-60px is-size-4">
+      {{ pageTitle }}
     </div>
     <div class="width-120px version-box is-size-7 has-text-grey">
       <div class="ui-version">
@@ -31,6 +36,7 @@
 import packageJson from '@/../package.json'
 import {defineComponent} from 'vue'
 import RequestsUtils from '@/assets/RequestsUtils'
+import DatasetsUtils from '@/assets/DatasetsUtils'
 
 export default defineComponent({
   name: 'HeaderMain',
@@ -40,11 +46,18 @@ export default defineComponent({
       apiVersion: RequestsUtils.reblazeAPIVersion,
     }
   },
-
+  computed: {
+    pageTitle(): string {
+      let title = this.$route?.meta?.title || ''
+      title = title.replace(':docType:', DatasetsUtils.titles[this.$route?.params?.doc_type])
+      return title
+    },
+  },
 })
 </script>
 
-<style scoped lang="scss">
+<style scoped
+       lang="scss">
 .container {
   display: flex;
   justify-content: space-between;
@@ -57,5 +70,11 @@ export default defineComponent({
 .logo {
   max-height: 42px;
   min-height: 42px;
+}
+
+.page-title {
+  left: 300px;
+  line-height: 60px;
+  position: fixed;
 }
 </style>

--- a/src/components/SecurityPoliciesConnections.vue
+++ b/src/components/SecurityPoliciesConnections.vue
@@ -10,26 +10,26 @@
         <th class="is-size-7 width-300px">Entry Match</th>
         <th class="is-size-7 width-70px has-text-centered">
           <a v-if="!newSecurityPolicyConnectionOpened"
-              class="has-text-grey-dark is-small new-connection-button"
-              data-qa="attach-to-site-btn"
-              title="Add new connection"
-              tabindex="0"
-              @click="openNewSecurityPolicyConnection"
-              @keypress.space.prevent
-              @keypress.space="openNewSecurityPolicyConnection"
-              @keypress.enter="openNewSecurityPolicyConnection">
-              <span class="icon is-small"><i class="fas fa-plus"></i></span>
+             class="has-text-grey-dark is-small new-connection-button"
+             data-qa="attach-to-site-btn"
+             title="Add new connection"
+             tabindex="0"
+             @click="openNewSecurityPolicyConnection"
+             @keypress.space.prevent
+             @keypress.space="openNewSecurityPolicyConnection"
+             @keypress.enter="openNewSecurityPolicyConnection">
+            <span class="icon is-small"><i class="fas fa-plus"></i></span>
           </a>
           <a v-else
-              class="has-text-grey-dark is-small new-connection-button"
-              data-qa="cancel-attaching-to-site"
-              title="Cancel adding new connection"
-              tabindex="0"
-              @click="closeNewSecurityPolicyConnection"
-              @keypress.space.prevent
-              @keypress.space="closeNewSecurityPolicyConnection"
-              @keypress.enter="closeNewSecurityPolicyConnection">
-              <span class="icon is-small"><i class="fas fa-minus"></i></span>
+             class="has-text-grey-dark is-small new-connection-button"
+             data-qa="cancel-attaching-to-site"
+             title="Cancel adding new connection"
+             tabindex="0"
+             @click="closeNewSecurityPolicyConnection"
+             @keypress.space.prevent
+             @keypress.space="closeNewSecurityPolicyConnection"
+             @keypress.enter="closeNewSecurityPolicyConnection">
+            <span class="icon is-small"><i class="fas fa-minus"></i></span>
           </a>
         </th>
       </tr>
@@ -41,13 +41,15 @@
           <td>
             <div class="select is-small">
               <select v-model="newSecurityPolicyConnectionDataMapId"
-                  @change="newSecurityPolicyConnectionDataChanged()"
-                  class="new-connection-map"
-                  data-qa="site-name-dropdown"
-                  title="Type">
-                  <option v-for="map in newSecurityPolicyConnections" :key="map.id" :value="map.id">
-                    {{ map.name }}
-                  </option>
+                      @change="newSecurityPolicyConnectionDataChanged()"
+                      class="new-connection-map"
+                      data-qa="site-name-dropdown"
+                      title="Type">
+                <option v-for="map in newSecurityPolicyConnections"
+                        :key="map.id"
+                        :value="map.id">
+                  {{ map.name }}
+                </option>
               </select>
             </div>
           </td>
@@ -60,23 +62,23 @@
           <td>
             <div class="select is-small">
               <select v-model="newSecurityPolicyConnectionData.entryIndex"
-                  class="new-connection-entry-index"
-                  data-qa="site-path-dropdown"
-                  title="Type">
-                  <option v-for="(mapEntry, index) in newSecurityPolicyConnectionEntries"
-                      :key="mapEntry.match"
-                      :value="index">
-                      {{ mapEntry.match }}
-                  </option>
+                      class="new-connection-entry-index"
+                      data-qa="site-path-dropdown"
+                      title="Type">
+                <option v-for="(mapEntry, index) in newSecurityPolicyConnectionEntries"
+                        :key="mapEntry.match"
+                        :value="index">
+                  {{ mapEntry.match }}
+                </option>
               </select>
             </div>
           </td>
           <td class="has-text-centered">
             <button title="Add new connection"
-                data-qa="add-new-connection-btn"
-                class="button is-light is-small add-new-connection"
-                @click="addNewSecurityPolicyConnection">
-                <span class="icon is-small"><i class="fas fa-plus fa-xs"></i></span>
+                    data-qa="add-new-connection-btn"
+                    class="button is-light is-small add-new-connection"
+                    @click="addNewSecurityPolicyConnection">
+              <span class="icon is-small"><i class="fas fa-plus fa-xs"></i></span>
             </button>
           </td>
         </template>
@@ -86,12 +88,13 @@
           </td>
         </template>
       </tr>
-      <tr v-for="(connection, index) in connectedSecurityPoliciesEntries" :key="index">
+      <tr v-for="(connection, index) in connectedSecurityPoliciesEntries"
+          :key="index">
         <td class="is-size-7 is-vcentered py-3 width-150px connected-entry-row"
             :title="connection[0]">
           <a title="Add new"
-              class="security-policy-referral-button"
-              @click="referToSecurityPolicy(connection.id)">
+             class="security-policy-referral-button"
+             @click="referToSecurityPolicy(connection.id)">
             {{ connection.name }}
           </a>
         </td>
@@ -110,36 +113,36 @@
         <td class="is-size-7 is-vcentered width-70px height-50px">
             <span v-show="currentEntryDeleteIndex !== index">
             <a tabindex="0"
-                title="Remove connection to the Security Policy"
-                data-qa="remove-attached-site-btn"
-                class="is-small has-text-grey remove-connection-button"
-                @click="setEntryDeleteIndex(index)"
-                @keypress.space.prevent
-                @keypress.space="setEntryDeleteIndex(index)"
-                @keypress.enter="setEntryDeleteIndex(index)">
+               title="Remove connection to the Security Policy"
+               data-qa="remove-attached-site-btn"
+               class="is-small has-text-grey remove-connection-button"
+               @click="setEntryDeleteIndex(index)"
+               @keypress.space.prevent
+               @keypress.space="setEntryDeleteIndex(index)"
+               @keypress.enter="setEntryDeleteIndex(index)">
               Remove
             </a>
             </span>
-            <span v-show="currentEntryDeleteIndex === index">
+          <span v-show="currentEntryDeleteIndex === index">
                 <a class="is-size-7 has-text-grey add-button confirm-remove-connection-button"
-                    data-qa="confirm-remove-btn"
-                    title="Confirm"
-                    tabindex="0"
-                    @click="removeSecurityPolicyConnection(connection.id, connection.entryMatch)"
-                    @keypress.space.prevent
-                    @keypress.space="removeSecurityPolicyConnection(connection.id, connection.entryMatch)"
-                    @keypress.enter="removeSecurityPolicyConnection(connection.id, connection.entryMatch)">
+                   data-qa="confirm-remove-btn"
+                   title="Confirm"
+                   tabindex="0"
+                   @click="removeSecurityPolicyConnection(connection.id, connection.entryMatch)"
+                   @keypress.space.prevent
+                   @keypress.space="removeSecurityPolicyConnection(connection.id, connection.entryMatch)"
+                   @keypress.enter="removeSecurityPolicyConnection(connection.id, connection.entryMatch)">
                 <i class="fas fa-check"></i> Confirm
                 </a>
                 <br/>
                 <a class="is-size-7 has-text-grey cancel-remove-connection-button"
-                    data-qa="cancel-remove-btn"
-                    title="Cancel"
-                    tabindex="0"
-                    @click="setEntryDeleteIndex(-1)"
-                    @keypress.space.prevent
-                    @keypress.space="setEntryDeleteIndex(-1)"
-                    @keypress.enter="setEntryDeleteIndex(-1)">
+                   data-qa="cancel-remove-btn"
+                   title="Cancel"
+                   tabindex="0"
+                   @click="setEntryDeleteIndex(-1)"
+                   @keypress.space.prevent
+                   @keypress.space="setEntryDeleteIndex(-1)"
+                   @keypress.enter="setEntryDeleteIndex(-1)">
                     <i class="fas fa-times"></i> Cancel
                 </a>
             </span>
@@ -157,10 +160,7 @@ import {defineComponent} from 'vue'
 import DatasetsUtils from '@/assets/DatasetsUtils'
 import RequestsUtils from '@/assets/RequestsUtils'
 import {AxiosResponse} from 'axios'
-import {
-  SecurityPolicy,
-  SecurityPolicyEntryMatch,
-} from '@/types'
+import {SecurityPolicy, SecurityPolicyEntryMatch} from '@/types'
 
 
 export default defineComponent({

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -54,7 +54,6 @@
 </template>
 
 <script lang="ts">
-// import RequestsUtils from '@/assets/RequestsUtils'
 import {defineComponent} from 'vue'
 import {mapStores} from 'pinia'
 import {useBranchesStore} from '@/stores/BranchesStore'

--- a/src/components/TagAutocompleteInput.vue
+++ b/src/components/TagAutocompleteInput.vue
@@ -215,7 +215,7 @@ export default defineComponent({
       }
       // get current tags from DB
       const response = await RequestsUtils.sendRequest({methodName: 'GET', url: `db/${this.db}/k/${this.key}/`})
-      const document = {...this.defaultKeyData, ...response.data}
+      const document = {...this.defaultKeyData, ...response?.data}
       // add each new tag to neutral group if does not exist anywhere
       for (let i = 0; i < tags.length; i++) {
         // set both the temporary tag and the tag in array to lowercase for easier logging later

--- a/src/doc-editors/GlobalFiltersEditor.vue
+++ b/src/doc-editors/GlobalFiltersEditor.vue
@@ -24,10 +24,10 @@
           <div class="field">
             <label class="checkbox is-size-7">
               <input type="checkbox"
-                     :style="(reblazeManaged || dynamicRuleManaged) ? {cursor: 'not-allowed'} : {cursor: 'pointer'}"
+                     :style="dynamicRuleManaged ? {cursor: 'not-allowed'} : {cursor: 'pointer'}"
                      data-qa="active-checkbox"
                      class="document-active"
-                     :disabled="reblazeManaged || dynamicRuleManaged"
+                     :disabled="dynamicRuleManaged"
                      @change="emitDocUpdate"
                      v-model="localDoc.active">
               Active

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -43,11 +43,17 @@ const routes: Array<RouteRecordRaw> = [
                 path: 'list',
                 name: 'ServerGroups/list',
                 component: ServerGroupsList,
+                meta: {
+                  title: 'Server Groups List',
+                },
               },
               {
                 path: 'config/:doc_id',
                 name: 'ServerGroups/config',
                 component: ServerGroupsEditor,
+                meta: {
+                  title: 'Server Groups Editor',
+                },
               },
             ],
           },
@@ -62,11 +68,17 @@ const routes: Array<RouteRecordRaw> = [
                 path: 'list',
                 name: 'RoutingProfiles/list',
                 component: RoutingProfileList,
+                meta: {
+                  title: 'Routing Profiles List',
+                },
               },
               {
                 path: 'config/:doc_id',
                 name: 'RoutingProfiles/config',
                 component: RoutingProfileEditor,
+                meta: {
+                  title: 'Routing Profiles Editor',
+                },
               },
             ],
           },
@@ -81,11 +93,17 @@ const routes: Array<RouteRecordRaw> = [
                 path: 'list',
                 name: 'MobileSDKs/list',
                 component: MobileSDKList,
+                meta: {
+                  title: 'Mobile SDKs List',
+                },
               },
               {
                 path: 'config/:doc_id',
                 name: 'MobileSDKs/config',
                 component: MobileSDKEditor,
+                meta: {
+                  title: 'Mobile SDKs Editor',
+                },
               },
             ],
           },
@@ -100,11 +118,17 @@ const routes: Array<RouteRecordRaw> = [
                 path: 'list',
                 name: 'ConfigTemplates/list',
                 component: ConfigTemplateList,
+                meta: {
+                  title: 'Config Templates List',
+                },
               },
               {
                 path: 'config/:doc_id',
                 name: 'ConfigTemplates/config',
                 component: ConfigTemplateEditor,
+                meta: {
+                  title: 'Config Templates Editor',
+                },
               },
             ],
           },
@@ -119,11 +143,17 @@ const routes: Array<RouteRecordRaw> = [
                 path: 'list',
                 name: 'DynamicRules/list',
                 component: DynamicRulesList,
+                meta: {
+                  title: 'Dynamic Rules List',
+                },
               },
               {
                 path: 'config/:doc_id',
                 name: 'DocumentEditor/DocType/config/DocID',
                 component: DocumentEditor,
+                meta: {
+                  title: 'Dynamic Rules Editor',
+                },
               },
             ],
           },
@@ -138,11 +168,17 @@ const routes: Array<RouteRecordRaw> = [
                 path: 'list',
                 name: 'BackendServices/list',
                 component: BackendServiceList,
+                meta: {
+                  title: 'Backend Services List',
+                },
               },
               {
                 path: 'config/:doc_id',
                 name: 'BackendServices/config',
                 component: BackendServiceEditor,
+                meta: {
+                  title: 'Backend Services Editor',
+                },
               },
             ],
           },
@@ -157,22 +193,70 @@ const routes: Array<RouteRecordRaw> = [
                 path: 'list',
                 name: 'DocumentList/DocType/list',
                 component: DocumentList,
+                meta: {
+                  title: ':docType: List',
+                },
               },
               {
                 path: 'config/:doc_id',
                 name: 'DocumentEditor/DocType/config/DocID',
                 component: DocumentEditor,
+                meta: {
+                  title: ':docType: Editor',
+                },
               },
             ],
           },
-          {path: 'version-control', name: 'VersionControl', component: VersionControl},
-          {path: 'publish', name: 'PublishChanges', component: PublishChanges},
+          {
+            path: 'version-control',
+            name: 'VersionControl',
+            component: VersionControl,
+            meta: {
+              title: 'Version Control',
+            },
+          },
+          {
+            path: 'publish',
+            name: 'PublishChanges',
+            component: PublishChanges,
+            meta: {
+              title: 'Publish Changes',
+            },
+          },
         ],
       },
-      {path: 'dashboard', name: 'DashboardDisplay', component: DashboardDisplay},
-      {path: 'quarantined', name: 'Quarantined', component: QuarantinedList},
-      {path: 'system-db', name: 'SystemDBEditor', component: SystemDBEditor},
-      {path: 'support', name: 'Support', component: HelpAndSupport},
+      {
+        path: 'dashboard',
+        name: 'DashboardDisplay',
+        component: DashboardDisplay,
+        meta: {
+          title: 'Dashboard',
+        },
+      },
+      {
+        path: 'quarantined',
+        name: 'Quarantined',
+        component: QuarantinedList,
+        meta: {
+          title: 'Quarantined',
+        },
+      },
+      {
+        path: 'system-db',
+        name: 'SystemDBEditor',
+        component: SystemDBEditor,
+        meta: {
+          title: 'System DB',
+        },
+      },
+      {
+        path: 'support',
+        name: 'Support',
+        component: HelpAndSupport,
+        meta: {
+          title: 'Help And Support',
+        },
+      },
     ],
   },
   {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -376,10 +376,15 @@ declare module CuriefenseClient {
     id: string
     name: string
     description: string
+    secret: string
+    var_name: string
     uid_header: string
     grace: string
+    grace_var_name: string
+    validator_type: string
     active_config: MobileSDKConfig[]
     signatures: MobileSDKSignature[]
+    support_legacy_sdk: boolean
   }
 
   type ConfigTemplate = {

--- a/src/views/DocumentEditor.vue
+++ b/src/views/DocumentEditor.vue
@@ -759,7 +759,7 @@ export default defineComponent({
     },
 
     async loadReferencedEdgeFunctionsDocsIDs() {
-      const response = await RequestsUtils.sendRequest({
+      const response = await RequestsUtils.sendReblazeRequest({
         methodName: 'GET',
         url: `configs/${this.selectedBranch}/d/routing-profiles/`,
       })

--- a/src/views/__tests__/DocumentList.spec.ts
+++ b/src/views/__tests__/DocumentList.spec.ts
@@ -24,7 +24,6 @@ import {setImmediate, setTimeout} from 'timers'
 import {nextTick} from 'vue'
 import {createRouter, createWebHistory} from 'vue-router'
 import {routes} from '@/router'
-import {COLUMN_OPTIONS_MAP} from '../documentListConst'
 
 jest.mock('axios')
 
@@ -723,7 +722,7 @@ describe.skip('DocumentList.vue', () => {
       }
       const branch = wrapper.vm.selectedBranch
       if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/`) {
-        const aclXFields = _.flatMap(COLUMN_OPTIONS_MAP['aclprofiles'], 'fieldNames')
+        const aclXFields = _.flatMap(wrapper.vm.columnOptionMap['aclprofiles'], 'fieldNames')
         aclXFields.unshift('id')
         if (config && config.headers && config.headers['x-fields'] === aclXFields.join(', ')) {
           return Promise.resolve({data: _.map(aclDocs, (i) => _.pick(i, aclXFields))})
@@ -737,7 +736,7 @@ describe.skip('DocumentList.vue', () => {
         return Promise.resolve({data: aclGitOldVersion})
       }
       if (path === `/conf/api/v3/configs/prod/d/globalfilters/`) {
-        const globalFilterXFields = _.flatMap(COLUMN_OPTIONS_MAP['globalfilters'], 'fieldNames')
+        const globalFilterXFields = _.flatMap(wrapper.vm.columnOptionMap['globalfilters'], 'fieldNames')
         globalFilterXFields.unshift('id')
         if (config && config.headers && config.headers['x-fields'] === globalFilterXFields.join(', ')) {
           return Promise.resolve({data: _.map(globalFilterDocs, (i) => _.pick(i, globalFilterXFields))})
@@ -746,7 +745,7 @@ describe.skip('DocumentList.vue', () => {
       }
       if (path === `/conf/api/v3/configs/zzz_branch/d/globalfilters/`) {
         globalFilterDocs.shift()
-        const globalFilterXFields = _.flatMap(COLUMN_OPTIONS_MAP['globalfilters'], 'fieldNames')
+        const globalFilterXFields = _.flatMap(wrapper.vm.columnOptionMap['globalfilters'], 'fieldNames')
         globalFilterXFields.unshift('id')
         if (config && config.headers && config.headers['x-fields'] === globalFilterXFields.join(', ')) {
           return Promise.resolve({data: _.map(globalFilterDocs, (i) => _.pick(i, globalFilterXFields))})
@@ -754,7 +753,7 @@ describe.skip('DocumentList.vue', () => {
         return Promise.resolve({data: globalFilterDocs})
       }
       if (path === `/conf/api/v3/configs/${branch}/d/securitypolicies/`) {
-        const securitypoliciesXFields = _.flatMap(COLUMN_OPTIONS_MAP['securitypolicies'], 'fieldNames')
+        const securitypoliciesXFields = _.flatMap(wrapper.vm.columnOptionMap['securitypolicies'], 'fieldNames')
         securitypoliciesXFields.unshift('id')
         if (config && config.headers && config.headers['x-fields'] === securitypoliciesXFields?.join(', ')) {
           return Promise.resolve({data: _.map(securityPoliciesDocs, (i) => _.pick(i, securitypoliciesXFields))})
@@ -762,7 +761,7 @@ describe.skip('DocumentList.vue', () => {
         return Promise.resolve({data: securityPoliciesDocs})
       }
       if (path === `/conf/api/v3/configs/${branch}/d/flowcontrol/`) {
-        const flowcontrolXFields = _.flatMap(COLUMN_OPTIONS_MAP?.flowcontrol, 'fieldNames')
+        const flowcontrolXFields = _.flatMap(wrapper.vm.columnOptionMap?.flowcontrol, 'fieldNames')
         flowcontrolXFields.unshift('id')
         if (config && config.headers && config.headers['x-fields'] === flowcontrolXFields.join(', ')) {
           return Promise.resolve({data: _.map(flowControlPolicyDocs, (i) => _.pick(i, flowcontrolXFields))})
@@ -770,7 +769,7 @@ describe.skip('DocumentList.vue', () => {
         return Promise.resolve({data: flowControlPolicyDocs})
       }
       if (path === `/conf/api/v3/configs/${branch}/d/contentfilterprofiles/`) {
-        const contentfilterprofilesXFields = _.flatMap(COLUMN_OPTIONS_MAP['contentfilterprofiles'], 'fieldNames')
+        const contentfilterprofilesXFields = _.flatMap(wrapper.vm.columnOptionMap['contentfilterprofiles'], 'fieldNames')
         contentfilterprofilesXFields.unshift('id')
         if (config && config.headers && config.headers['x-fields'] === contentfilterprofilesXFields.join(', ')) {
           return Promise.resolve({
@@ -782,7 +781,7 @@ describe.skip('DocumentList.vue', () => {
         return Promise.resolve({data: contentFilterProfilesDocs})
       }
       if (path === `/conf/api/v3/configs/${branch}/d/contentfilterrules/`) {
-        const contentfilterrulesXFields = _.flatMap(COLUMN_OPTIONS_MAP['contentfilterrules'], 'fieldNames')
+        const contentfilterrulesXFields = _.flatMap(wrapper.vm.columnOptionMap['contentfilterrules'], 'fieldNames')
         contentfilterrulesXFields.unshift('id')
         if (config && config.headers && config.headers['x-fields'] === contentfilterrulesXFields.join(', ')) {
           return Promise.resolve({data: _.map(contentFilterRulesDocs, (i) => _.pick(i, contentfilterrulesXFields))})
@@ -790,7 +789,7 @@ describe.skip('DocumentList.vue', () => {
         return Promise.resolve({data: contentFilterRulesDocs})
       }
       if (path === `/conf/api/v3/configs/${branch}/d/ratelimits/`) {
-        const ratelimitsXFields = _.flatMap(COLUMN_OPTIONS_MAP['ratelimits'], 'fieldNames')
+        const ratelimitsXFields = _.flatMap(wrapper.vm.columnOptionMap['ratelimits'], 'fieldNames')
         ratelimitsXFields.unshift('id')
         if (config && config.headers && config.headers['x-fields'] === ratelimitsXFields.join(', ')) {
           return Promise.resolve({data: _.map(rateLimitsDocs, (i) => _.pick(i, ratelimitsXFields))})
@@ -1180,7 +1179,7 @@ describe.skip('DocumentList.vue', () => {
           }
           const branch = wrapper.vm.selectedBranch
           if (path === `/conf/api/v3/configs/${branch}/d/aclprofiles/`) {
-            const aclXFields = _.flatMap(COLUMN_OPTIONS_MAP['aclprofiles'], 'fieldNames')
+            const aclXFields = _.flatMap(wrapper.vm.columnOptionMap['aclprofiles'], 'fieldNames')
             aclXFields.unshift('id')
             if (config && config.headers && config.headers['x-fields'] === aclXFields.join(', ')) {
               return Promise.resolve({data: _.map(aclDocs, (i) => _.pick(i, aclXFields))})
@@ -1418,9 +1417,9 @@ describe.skip('DocumentList.vue', () => {
         })
         // allow all requests to finish
         setImmediate(() => {
-          expect(wrapper.vm.columns).toEqual(COLUMN_OPTIONS_MAP[docType])
+          expect(wrapper.vm.columns).toEqual(wrapper.vm.columnOptionMap[docType])
           const defaultDoc = DatasetsUtils.newDocEntryFactory[docType]()
-          COLUMN_OPTIONS_MAP[docType].forEach((columnOptions) => {
+          wrapper.vm.columnOptionMap[docType].forEach((columnOptions) => {
             if (typeof columnOptions.displayFunction === 'function') {
               expect(typeof columnOptions.displayFunction(defaultDoc) === 'string')
             }


### PR DESCRIPTION
Add page titles to all pages in the system
Fix bug in Security Policy where deleting map entry didn't save properly
Fix bug in Security Policy where default entries were editable and deletable
Fix bug in Flow Control where new Flow Control wrongly connected the two sections to the same entity instead of cloning it
Fix tooltip title for Security Policy connections table in Rate Limit editor - name of connected Security Policy
Fix bug in Edge Functions where we loaded referencing Routing Profiles from confserver instead of Reblaze backend
Fix bug in Global Filter where active box was disabled for Reblaze managed documents
Fix bug in Global Filter rule where creating a new section or entry did not open a collapsed rule
Fix bug in Mobile SDKs list preventing the creation of new Mobile SDKs
Fix unit tests import error

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>