### PR TITLE
Enable metabase dashboards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "bulma-toast": "^2.3.0",
         "core-js": "^3.8.3",
         "jsoneditor": "^9.5.6",
+        "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.20",
         "node-polyfill-webpack-plugin": "^2.0.1",
         "pinia": "^2.0.23",
@@ -5704,6 +5705,11 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -7352,6 +7358,14 @@
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -12692,6 +12706,54 @@
         "jsonrepair": "bin/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -12844,6 +12906,36 @@
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -12867,6 +12959,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -13642,8 +13739,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -24118,6 +24214,11 @@
         "ieee754": "^1.1.13"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -25358,6 +25459,14 @@
       "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.1.tgz",
       "integrity": "sha512-wK2sCs4feiiJeFXn3zvY0p41mdU5VUgbgs1rNsc/y5ngFUijdWd+iIN8eoyuZHKB8xN6BL4PdWmzqFmxNg6V2w==",
       "dev": true
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -29265,6 +29374,49 @@
       "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-2.2.1.tgz",
       "integrity": "sha512-o9Je8TceILo872uQC9fIBJm957j1Io7z8Ca1iWIqY6S5S65HGE9XN7XEEw7+tUviB9Vq4sygV89MVTxl+rhZyg=="
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -29389,6 +29541,36 @@
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -29412,6 +29594,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -29993,8 +30180,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "7.2.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bulma-toast": "^2.3.0",
     "core-js": "^3.8.3",
     "jsoneditor": "^9.5.6",
+    "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",
     "node-polyfill-webpack-plugin": "^2.0.1",
     "pinia": "^2.0.23",

--- a/src/views/Dashboards.vue
+++ b/src/views/Dashboards.vue
@@ -140,8 +140,8 @@ export default defineComponent({
         url: `db/system/`,
       })
       const systemDBData = response?.data
-      this.metabaseURL = systemDBData?.links?.metabase_url || this.defaultMetabaseURL
       const dashboardsInfo = systemDBData?.dashboardsinfo
+      this.metabaseURL = dashboardsInfo.metabaseURL || this.defaultMetabaseURL
       this.metabaseKey = dashboardsInfo?.metabaseKey || ''
       if (dashboardsInfo?.dashboards?.length) {
         this.dashboards = dashboardsInfo.dashboards

--- a/src/views/Dashboards.vue
+++ b/src/views/Dashboards.vue
@@ -1,56 +1,5 @@
 <template>
   <div class="card-content">
-    <div class="media mb-2">
-      <div class="media-content">
-        <div class="field is-grouped">
-          <div class="control search-wrapper">
-            <input class="input is-small is-fullwidth filter-input"
-                   placeholder="Filters, comma separated. Available filters: `proxy`, `appid`, and `profile`."
-                   v-model="searchFilter"/>
-          </div>
-          <p class="control">
-            <Datepicker v-model="date"
-                        range
-                        utc
-                        enableSeconds
-                        format="yyyy-MM-dd HH:mm"
-                        inputClassName="input is-small is-size-7 width-260px date-picker-input"
-                        :monthChangeOnScroll="false"
-                        :clearable="false"
-                        :presetRanges="presetRanges"
-                        @open="loadPresetRanges">
-            </Datepicker>
-          </p>
-          <p class="control">
-            <button class="button is-small search-button"
-                    :class="{'is-loading': isSearchLoading}"
-                    @click="loadData()"
-                    title="Search"
-                    data-qa="search-button">
-              <span class="icon is-small">
-                <i class="fas fa-search"></i>
-              </span>
-              <span>
-                Search
-              </span>
-            </button>
-          </p>
-          <p class="control">
-            <button class="button is-small clear-search-button"
-                    @click="clearSearch()"
-                    title="Clear filter"
-                    data-qa="clear-search-button">
-              <span class="icon is-small">
-                <i class="fas fa-times"></i>
-              </span>
-              <span>
-                Clear
-              </span>
-            </button>
-          </p>
-        </div>
-      </div>
-    </div>
     <div class="tabs-wrapper mb-5">
       <div class="tabs"
            data-qa="dashboard-tabs">
@@ -67,30 +16,83 @@
         </ul>
       </div>
     </div>
-    <div v-if="!data?.length"
-         class="has-text-centered is-fullwidth">
-      <div v-if="isSearchLoading">
-        <button class="button is-outlined is-text is-small is-loading dashboard-loading">
-          Loading
-        </button>
+    <div v-show="dashboards[activeDashboardIndex]?.useDashboard">
+      <div class="media mb-5">
+        <div class="media-content">
+          <div class="field is-grouped">
+            <div class="control search-wrapper">
+              <input class="input is-small is-fullwidth filter-input"
+                     placeholder="Filters, comma separated. Available filters: `proxy`, `appid`, and `profile`."
+                     v-model="searchFilter"/>
+            </div>
+            <p class="control">
+              <Datepicker v-model="date"
+                          range
+                          utc
+                          enableSeconds
+                          format="yyyy-MM-dd HH:mm"
+                          inputClassName="input is-small is-size-7 width-260px date-picker-input"
+                          :monthChangeOnScroll="false"
+                          :clearable="false"
+                          :presetRanges="presetRanges"
+                          @open="loadPresetRanges">
+              </Datepicker>
+            </p>
+            <p class="control">
+              <button class="button is-small search-button"
+                      :class="{'is-loading': isSearchLoading}"
+                      @click="loadData()"
+                      title="Search"
+                      data-qa="search-button">
+              <span class="icon is-small">
+                <i class="fas fa-search"></i>
+              </span>
+                <span>
+                Search
+              </span>
+              </button>
+            </p>
+            <p class="control">
+              <button class="button is-small clear-search-button"
+                      @click="clearSearch()"
+                      title="Clear filter"
+                      data-qa="clear-search-button">
+              <span class="icon is-small">
+                <i class="fas fa-times"></i>
+              </span>
+                <span>
+                Clear
+              </span>
+              </button>
+            </p>
+          </div>
+        </div>
       </div>
-      <div v-else>
-        Your search did not match any data
+      <div v-if="!data?.length"
+           class="has-text-centered is-fullwidth">
+        <div v-if="isSearchLoading">
+          <button class="button is-outlined is-text is-small is-loading dashboard-loading">
+            Loading
+          </button>
+        </div>
+        <div v-else>
+          Your search did not match any data
+        </div>
+      </div>
+      <div v-show="dashboards[activeDashboardIndex]?.useDashboard === 'default' && data?.length">
+        <rbz-dashboard-default :data="data"
+                               :loading="isSearchLoading">
+        </rbz-dashboard-default>
+      </div>
+      <div v-show="dashboards[activeDashboardIndex]?.useDashboard === 'threats' && data?.length">
       </div>
     </div>
-    <div v-show="dashboards[activeDashboardIndex]?.useDashboard === 'default' && data?.length">
-      <rbz-dashboard-default :data="data"
-                             :loading="isSearchLoading">
-      </rbz-dashboard-default>
-    </div>
-    <div v-show="dashboards[activeDashboardIndex]?.useDashboard === 'threats' && data?.length">
-    </div>
-    <div v-if="dashboards[activeDashboardIndex]?.metabaseId && data?.length">
-      <!--        <iframe :src="getDashboardURL(dashboards[activeDashboardIndex]?.metabaseId)"-->
-      <!--                width="100%"-->
-      <!--                height="600"-->
-      <!--                allowtransparency>-->
-      <!--        </iframe>-->
+    <div v-if="dashboards[activeDashboardIndex]?.metabaseId">
+      <iframe :src="getDashboardURL(dashboards[activeDashboardIndex].metabaseId)"
+              width="100%"
+              height="600"
+              allowtransparency>
+      </iframe>
     </div>
   </div>
 </template>
@@ -102,6 +104,7 @@ import RbzDashboardDefault from '@/reblaze-dashboards/DefaultDashboard.vue'
 import Datepicker from '@vuepic/vue-datepicker'
 import {GenericObject} from '@/types'
 
+const jwt = require('jsonwebtoken')
 const MS_PER_MINUTE = 60000
 const HOUR = 60 * MS_PER_MINUTE
 
@@ -121,6 +124,7 @@ export default defineComponent({
       defaultMetabaseURL: defaultMetabaseURL,
       metabaseURL: defaultMetabaseURL,
       dashboards: [] as DashboardData[],
+      metabaseKey: '',
       activeDashboardIndex: -1,
       data: [],
       searchFilter: '',
@@ -137,8 +141,10 @@ export default defineComponent({
       })
       const systemDBData = response?.data
       this.metabaseURL = systemDBData?.links?.metabase_url || this.defaultMetabaseURL
-      this.dashboards = systemDBData?.dashboards || []
-      if (this.dashboards.length) {
+      const dashboardsInfo = systemDBData?.dashboardsinfo
+      this.metabaseKey = dashboardsInfo?.metabaseKey || ''
+      if (dashboardsInfo?.dashboards?.length) {
+        this.dashboards = dashboardsInfo.dashboards
         this.activeDashboardIndex = 0
       }
     },
@@ -189,16 +195,15 @@ export default defineComponent({
       this.isSearchLoading = false
     },
 
-    // getDashboardURL(metabaseId: number) {
-    //   const METABASE_SECRET_KEY = ''
-    //   const payload = {
-    //     resource: {dashboard: metabaseId},
-    //     params: {},
-    //     exp: Math.round(Date.now() / 1000) + (10 * 60), // 10 minute expiration
-    //   }
-    //   const token = jwt.sign(payload, METABASE_SECRET_KEY)
-    //   return `${this.metabaseURL}/embed/dashboard/${token}#theme=transparent&bordered=false&titled=true`
-    // },
+    getDashboardURL(metabaseId: number) {
+      const payload = {
+        resource: {dashboard: metabaseId},
+        params: {},
+        exp: Math.round(Date.now() / 1000) + (10 * 60), // 10 minute expiration
+      }
+      const token = jwt.sign(payload, this.metabaseKey)
+      return `${this.metabaseURL}/embed/dashboard/${token}#theme=transparent&bordered=false&titled=true`
+    },
 
     clearSearch() {
       this.searchFilter = ''


### PR DESCRIPTION
Format for `dashboardsinfo` key in `system` namespace below
Move filter for Reblaze Dashboards to be inside the tabs

```
{
  "dashboards": [
    {
      "title": "Reblaze Dashboard",
      "useDashboard": "default"
    },
    {
      "title": "Metabase Dashboard",
      "metabaseId": "1"
    }
  ],
  "metabaseKey": "string"
  "metabaseURL": "" // If none specified will use the default http://localhost:3000/
}
```

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>