### PR TITLE
Document List changes

### DIFF
--- a/src/assets/DatasetsUtils.ts
+++ b/src/assets/DatasetsUtils.ts
@@ -215,9 +215,11 @@ const newDocEntryFactory: { [key: string]: Function } = {
       'match': `${id}.example.com`,
       'description': 'New Security Policy Description and Remarks',
       'tags': [],
-      'session': {
-        'attrs': 'ip',
-      },
+      'session': [
+        {
+          'attrs': 'ip',
+        },
+      ],
       'session_ids': [],
       'map': [
         {

--- a/src/components/EntriesRelationList.vue
+++ b/src/components/EntriesRelationList.vue
@@ -586,7 +586,7 @@ export default defineComponent({
       const id = 'firstAttrEmpty'
       this.clearError(id)
       const firstAttrValue = this.newEntryItem.firstAttr.trim()
-      if (!firstAttrValue && this.newEntryItemCounter.entries < this.newEntryItemCounter.annotations) {
+      if (!firstAttrValue || this.newEntryItemCounter.entries < this.newEntryItemCounter.annotations) {
         this.addError(id)
       }
     },

--- a/src/components/LimitOption.vue
+++ b/src/components/LimitOption.vue
@@ -35,8 +35,7 @@
            :class="selectedNameColumnClass"
            v-if="selectedType !== 'self'">
         <div v-if="isCategoryArgsCookiesHeaders(selectedType)"
-             :class="{control: true, 'is-fullwidth': true}"
-             class="has-icons-left">
+             class="control is-fullwidth has-icons-left">
           <input type="text"
                  title="Name"
                  :class="{ 'is-danger': selectedName === '' }"
@@ -76,13 +75,14 @@
       <div class="column is-narrow"
            v-if="!!showRemove">
         <button
-            :class="['button', 'is-light', 'is-small', 'remove-icon', 'is-small',
-                    removable ? 'has-text-grey' : 'has-text-grey-light is-disabled']"
+            :class="removable ? 'has-text-grey' : 'has-text-grey-light is-disabled'"
             :disabled="!removable"
-            class="remove-option-button"
+            class="button is-light is-small remove-icon remove-option-button"
             title="Click to remove"
             @click="$emit('remove')">
-          <span class="icon is-small"><i class="fas fa-trash fa-xs"></i></span>
+          <span class="icon is-small">
+            <i class="fas fa-trash fa-xs"></i>
+          </span>
         </button>
       </div>
     </div>

--- a/src/components/QuarantinedList.vue
+++ b/src/components/QuarantinedList.vue
@@ -56,6 +56,7 @@ export default defineComponent({
           fieldNames: ['count'],
           isSortable: true,
           isSearchable: true,
+          isNumber: true,
           classes: 'width-100px',
         },
         {

--- a/src/components/RbzTable.vue
+++ b/src/components/RbzTable.vue
@@ -108,8 +108,9 @@
           class="data-row">
         <td v-for="(col, index) in columns"
             :key="index"
-            :title="row[col.title]">
-          <div class="is-size-7 vertical-scroll data-cell"
+            :title="row[col.title]"
+        class="data-cell">
+          <div class="is-size-7 data-cell-content"
                :class="col.classes">
             <span v-if="col.displayFunction"
                   v-html="col.displayFunction(row)"
@@ -258,7 +259,7 @@ export default defineComponent({
         return _.reduce(
             keys,
             (match: boolean, key: string) => {
-              let getFilterValue: (item: any) => string
+              let getFilterValue: ColumnOptions['displayFunction']
               const filterColumn = this.columns.find((column) => {
                 return column.title === key
               })
@@ -269,11 +270,11 @@ export default defineComponent({
                   return item[filterColumn?.fieldNames[0]]?.toString() || ''
                 }
               }
-              const filterValue = getFilterValue(item)?.toLowerCase() || ''
+              const filterValue = getFilterValue(item)?.toString().toLowerCase() || ''
               return (match && filterValue.includes(this.filter[key].toLowerCase()))
             }, true)
       }).sort((a: GenericObject, b: GenericObject) => {
-        let getSortValue: (item: GenericObject) => string
+        let getSortValue: ColumnOptions['displayFunction']
         if (this.sortColumnDisplayFunction) {
           getSortValue = this.sortColumnDisplayFunction
         } else {
@@ -291,8 +292,8 @@ export default defineComponent({
         let sortValueA = getSortValue(a)
         let sortValueB = getSortValue(b)
         if (!this.sortColumnIsNumber) {
-          sortValueA = sortValueA.toLowerCase()
-          sortValueB = sortValueB.toLowerCase()
+          sortValueA = sortValueA.toString().toLowerCase()
+          sortValueB = sortValueB.toString().toLowerCase()
         }
         if (sortValueA < sortValueB) {
           return -1 * sortModifier
@@ -492,6 +493,10 @@ export default defineComponent({
 }
 
 .rbz-table .data-cell {
-  max-height: 4.5rem;
+  vertical-align: middle;
+}
+
+.rbz-table .data-cell-content {
+  max-height: 1.75rem;
 }
 </style>

--- a/src/doc-editors/ACLEditor.vue
+++ b/src/doc-editors/ACLEditor.vue
@@ -2,23 +2,43 @@
   <div class="card-content">
     <div class="media">
       <div class="media-content">
-        <div class="card collapsible-card" :class="{ collapsed: isDataCollapsed }">
+        <div class="card collapsible-card"
+             :class="{ collapsed: isDataCollapsed }">
           <div class="card-content px-0 py-0">
             <div class="media collapsible px-5 py-5 mb-0"
-               @click="isDataCollapsed = !isDataCollapsed">
-            <div class="media-content">
-              <p v-show="!isDataCollapsed" class="title is-5"></p>
-              <p v-show="isDataCollapsed" class="is-5">
-                <span class="inline-collapsed-header"><span class="label is-small mr-1"> Name: </span>{{localDoc.name}}</span>
-                <span class="inline-collapsed-header"><span class="label is-small mr-1"> ID: </span>{{localDoc.id}}</span>
-                <span class="inline-collapsed-header"><span class="label is-small mr-1"> Tags: </span> {{localDoc.tags.join(', ')}}</span>
-              </p>
-            </div>
-            <span v-show="isDataCollapsed">
-              <i class="fas fa-angle-down" aria-hidden="true"></i>
+                 @click="isDataCollapsed = !isDataCollapsed">
+              <div class="media-content">
+                <p v-show="!isDataCollapsed"
+                   class="title is-5"></p>
+                <p v-show="isDataCollapsed"
+                   class="is-5">
+                <span class="inline-collapsed-header">
+                  <span class="label is-small mr-1">
+                    Name:
+                  </span>
+                  {{ localDoc.name }}
+                </span>
+                  <span class="inline-collapsed-header">
+                  <span class="label is-small mr-1">
+                    ID:
+                  </span>
+                  {{ localDoc.id }}
+                </span>
+                  <span class="inline-collapsed-header">
+                  <span class="label is-small mr-1">
+                    Tags:
+                  </span>
+                  {{ selectedDocTags }}
+                </span>
+                </p>
+              </div>
+              <span v-show="isDataCollapsed">
+              <i class="fas fa-angle-down"
+                 aria-hidden="true"></i>
             </span>
-            <span v-show="!isDataCollapsed">
-              <i class="fas fa-angle-up" aria-hidden="true"></i>
+              <span v-show="!isDataCollapsed">
+              <i class="fas fa-angle-up"
+                 aria-hidden="true"></i>
             </span>
             </div>
             <div class="content collapsible-content px-5 py-5">
@@ -35,11 +55,11 @@
                     </label>
                     <div class="control">
                       <input class="input is-small document-name"
-                            title="Document name"
-                            placeholder="Document name"
-                            @change="emitDocUpdate"
-                            data-qa="acl-document-name"
-                            v-model="localDoc.name"/>
+                             title="Document name"
+                             placeholder="Document name"
+                             @change="emitDocUpdate"
+                             data-qa="acl-document-name"
+                             v-model="localDoc.name"/>
                     </div>
                   </div>
                   <div class="field textarea-field">
@@ -77,13 +97,13 @@
                   <div class="field">
                     <label class="label is-small">Tags</label>
                     <div class="control"
-                        data-qa="tag-input">
+                         data-qa="tag-input">
                       <tag-autocomplete-input :initial-tag="selectedDocTags"
                                               :selection-type="'multiple'"
-                                              @tag-changed="selectedDocTags = $event" />
+                                              @tag-changed="selectedDocTags = $event"/>
                     </div>
                     <labeled-tags title="Automatic Tags"
-                                  :tags="automaticTags" />
+                                  :tags="automaticTags"/>
                   </div>
                 </div>
               </div>
@@ -133,7 +153,7 @@
                                         :selection-type="'single'"
                                         :auto-focus="true"
                                         @keydown.esc="cancelAddNewTag"
-                                        @tag-submitted="addNewEntry(operation, $event)" />
+                                        @tag-submitted="addNewEntry(operation, $event)"/>
               </td>
               <td class="is-size-7 width-20px">
                 <a title="add new entry"

--- a/src/doc-editors/BackendServicesEditor.vue
+++ b/src/doc-editors/BackendServicesEditor.vue
@@ -335,10 +335,6 @@ export default defineComponent({
     selectedDocNotDeletable(): boolean {
       return !this.selectedBackendService ||
           this.selectedBackendService.id.startsWith('__') || // Default entries
-          this.selectedBackendService.id.startsWith('rl-') || // Reblaze-managed Rate Limits
-          this.selectedBackendService.id.startsWith('action-') || // Reblaze-managed Custom Responses
-          this.selectedBackendService.id.startsWith('rbz-') || // Reblaze-managed Global Filters
-          this.selectedBackendService.id.startsWith('dr_') || // Dynamic-Rule-managed Global Filters
           this.isDocReferenced
     },
 

--- a/src/doc-editors/ConfigTemplatesEditor.vue
+++ b/src/doc-editors/ConfigTemplatesEditor.vue
@@ -588,10 +588,6 @@ export default defineComponent({
     selectedDocNotDeletable(): boolean {
       return !this.selectedConfigTemplate ||
           this.selectedConfigTemplate.id.startsWith('__') || // Default entries
-          this.selectedConfigTemplate.id.startsWith('rl-') || // Reblaze-managed Rate Limits
-          this.selectedConfigTemplate.id.startsWith('action-') || // Reblaze-managed Custom Responses
-          this.selectedConfigTemplate.id.startsWith('rbz-') || // Reblaze-managed Global Filters
-          this.selectedConfigTemplate.id.startsWith('dr_') || // Dynamic-Rule-managed Global Filters
           this.isDocReferenced
     },
 

--- a/src/doc-editors/DynamicRulesEditor.vue
+++ b/src/doc-editors/DynamicRulesEditor.vue
@@ -134,7 +134,7 @@
                  data-qa="tag-input">
               <tag-autocomplete-input :initial-tag="selectedDocTags"
                                       :selection-type="'multiple'"
-                                      @tag-changed="selectedDocTags = $event" />
+                                      @tag-changed="selectedDocTags = $event"/>
             </div>
           </div>
         </div>
@@ -154,7 +154,7 @@
                 <tr v-for="(tag, tagIndex) in localDoc[filter]"
                     :key="tagIndex">
                   <td class="tag-cell ellipsis"
-                      :class=" duplicateTags[tag] ? 'has-text-danger' : '' "
+                      :class="duplicateTags[tag] ? 'has-text-danger' : ''"
                       :title="tag">
                     {{ tag }}
                   </td>
@@ -179,7 +179,7 @@
                                             :selection-type="'single'"
                                             :auto-focus="true"
                                             @keydown.esc="cancelAddNewTag"
-                                            @tag-submitted="addNewTag(filter, $event)" />
+                                            @tag-submitted="addNewTag(filter, $event)"/>
                   </td>
                   <td class="is-size-7 width-20px">
                     <a title="add new entry"

--- a/src/doc-editors/GlobalFiltersEditor.vue
+++ b/src/doc-editors/GlobalFiltersEditor.vue
@@ -1,23 +1,43 @@
 <template>
   <div class="card-content">
     <div class="content">
-      <div class="card collapsible-card" :class="{ collapsed: isDataCollapsed }">
+      <div class="card collapsible-card"
+           :class="{ collapsed: isDataCollapsed }">
         <div class="card-content px-0 py-0">
           <div class="media collapsible px-5 py-5 mb-0"
                @click="isDataCollapsed = !isDataCollapsed">
             <div class="media-content">
-              <p v-show="!isDataCollapsed" class="title is-5"></p>
-              <p v-show="isDataCollapsed" class="is-5">
-                <span class="inline-collapsed-header"><span class="label is-small mr-1"> Name: </span>{{localDoc.name}}</span>
-                <span class="inline-collapsed-header"><span class="label is-small mr-1"> ID: </span>{{localDoc.id}}</span>
-                <span class="inline-collapsed-header"><span class="label is-small mr-1"> Tags: </span> {{localDoc.tags.join(', ')}}</span>
+              <p v-show="!isDataCollapsed"
+                 class="title is-5"></p>
+              <p v-show="isDataCollapsed"
+                 class="is-5">
+                <span class="inline-collapsed-header">
+                  <span class="label is-small mr-1">
+                    Name:
+                  </span>
+                  {{ localDoc.name }}
+                </span>
+                <span class="inline-collapsed-header">
+                  <span class="label is-small mr-1">
+                    ID:
+                  </span>
+                  {{ localDoc.id }}
+                </span>
+                <span class="inline-collapsed-header">
+                  <span class="label is-small mr-1">
+                    Tags:
+                  </span>
+                  {{ selectedDocTags }}
+                </span>
               </p>
             </div>
             <span v-show="isDataCollapsed">
-              <i class="fas fa-angle-down" aria-hidden="true"></i>
+              <i class="fas fa-angle-down"
+                 aria-hidden="true"></i>
             </span>
             <span v-show="!isDataCollapsed">
-              <i class="fas fa-angle-up" aria-hidden="true"></i>
+              <i class="fas fa-angle-up"
+                 aria-hidden="true"></i>
             </span>
           </div>
           <div class="content collapsible-content px-5 py-5">
@@ -33,61 +53,61 @@
                   </label>
                   <div class="control">
                     <input class="input is-small document-name"
-                          data-qa="list-name-input"
-                          title="List name"
-                          placeholder="List name"
-                          @change="emitDocUpdate"
-                          v-model="localDoc.name"
-                          :disabled="reblazeManaged || dynamicRuleManaged"/>
+                           data-qa="list-name-input"
+                           title="List name"
+                           placeholder="List name"
+                           @change="emitDocUpdate"
+                           v-model="localDoc.name"
+                           :disabled="reblazeManaged || dynamicRuleManaged"/>
                   </div>
                 </div>
                 <div class="field">
                   <label class="checkbox is-size-7">
                     <input type="checkbox"
-                          :style="dynamicRuleManaged ? {cursor: 'not-allowed'} : {cursor: 'pointer'}"
-                          data-qa="active-checkbox"
-                          class="document-active"
-                          :disabled="dynamicRuleManaged"
-                          @change="emitDocUpdate"
-                          v-model="localDoc.active">
+                           :style="dynamicRuleManaged ? {cursor: 'not-allowed'} : {cursor: 'pointer'}"
+                           data-qa="active-checkbox"
+                           class="document-active"
+                           :disabled="dynamicRuleManaged"
+                           @change="emitDocUpdate"
+                           v-model="localDoc.active">
                     Active
                   </label>
                 </div>
                 <div class="field">
                   <label class="label is-small">Tags</label>
                   <div class="control"
-                      data-qa="tag-input">
+                       data-qa="tag-input">
                     <tag-autocomplete-input :initial-tag="selectedDocTags"
                                             :selection-type="'multiple'"
                                             :editable="!dynamicRuleManaged"
-                                            @tag-changed="selectedDocTags = $event" />
+                                            @tag-changed="selectedDocTags = $event"/>
                   </div>
                 </div>
                 <div class="field">
                   <a v-if="externalSource"
-                    class="is-small has-text-grey is-size-7 is-pulled-right update-now-button"
-                    data-qa="update-now-btn"
-                    tabindex="0"
-                    disabled="dynamicRuleManaged"
-                    @click="fetchList"
-                    @keypress.space.prevent
-                    @keypress.space="fetchList"
-                    @keypress.enter="fetchList">
+                     class="is-small has-text-grey is-size-7 is-pulled-right update-now-button"
+                     data-qa="update-now-btn"
+                     tabindex="0"
+                     disabled="dynamicRuleManaged"
+                     @click="fetchList"
+                     @keypress.space.prevent
+                     @keypress.space="fetchList"
+                     @keypress.enter="fetchList">
                     Update now
                   </a>
                   <label class="label is-small">Source</label>
                   <div class="control">
                     <input class="input is-small document-source"
-                          data-qa="source-input"
-                          title="List source"
-                          placeholder="List source"
-                          @change="emitDocUpdate"
-                          v-model="localDoc.source"
-                          :disabled="reblazeManaged || dynamicRuleManaged"/>
+                           data-qa="source-input"
+                           title="List source"
+                           placeholder="List source"
+                           @change="emitDocUpdate"
+                           v-model="localDoc.source"
+                           :disabled="reblazeManaged || dynamicRuleManaged"/>
                   </div>
                   <p class="help"
-                    v-if="externalSource && !dynamicRuleManaged"
-                    :title="fullFormattedModifiedDate">
+                     v-if="externalSource && !dynamicRuleManaged"
+                     :title="fullFormattedModifiedDate">
                     Updated @ {{ formattedModifiedDate }}
                   </p>
                 </div>
@@ -136,7 +156,7 @@
       <div class="columns">
         <div class="column is-12">
           <div class="field">
-          <label class="label is-small">Rule</label>
+            <label class="label is-small">Rule</label>
             <entries-relation-list v-model:rule="localDoc.rule"
                                    @update:rule="emitDocUpdate"
                                    @invalid="emitFormInvalid"

--- a/src/doc-editors/MobileSDKsEditor.vue
+++ b/src/doc-editors/MobileSDKsEditor.vue
@@ -405,10 +405,6 @@ export default defineComponent({
     selectedDocNotDeletable(): boolean {
       return !this.selectedMobileSDK ||
           this.selectedMobileSDK.id.startsWith('__') || // Default entries
-          this.selectedMobileSDK.id.startsWith('rl-') || // Reblaze-managed Rate Limits
-          this.selectedMobileSDK.id.startsWith('action-') || // Reblaze-managed Custom Responses
-          this.selectedMobileSDK.id.startsWith('rbz-') || // Reblaze-managed Global Filters
-          this.selectedMobileSDK.id.startsWith('dr_') || // Dynamic-Rule-managed Global Filters
           this.isDocReferenced
     },
 

--- a/src/doc-editors/RoutingProfilesEditor.vue
+++ b/src/doc-editors/RoutingProfilesEditor.vue
@@ -409,10 +409,6 @@ export default defineComponent({
     selectedDocNotDeletable(): boolean {
       return !this.selectedRoutingProfile ||
           this.selectedRoutingProfile.id.startsWith('__') || // Default entries
-          this.selectedRoutingProfile.id.startsWith('rl-') || // Reblaze-managed Rate Limits
-          this.selectedRoutingProfile.id.startsWith('action-') || // Reblaze-managed Custom Responses
-          this.selectedRoutingProfile.id.startsWith('rbz-') || // Reblaze-managed Global Filters
-          this.selectedRoutingProfile.id.startsWith('dr_') || // Dynamic-Rule-managed Global Filters
           this.isDocReferenced
     },
 

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -27,7 +27,7 @@
                   <span class="label is-small mr-1">
                     Tags:
                   </span>
-                  {{ localDoc.tags.join(', ') }}
+                  {{ selectedDocTags }}
                 </span>
               </p>
             </div>

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -1,43 +1,63 @@
 <template>
   <div class="card-content">
     <div class="content">
-      <div class="card collapsible-card" :class="{ collapsed: isDataCollapsed }">
+      <div class="card collapsible-card"
+           :class="{ collapsed: isDataCollapsed }">
         <div class="card-content px-0 py-0">
           <div class="media collapsible px-5 py-5 mb-0"
                @click="isDataCollapsed = !isDataCollapsed">
             <div class="media-content">
-              <p v-show="!isDataCollapsed" class="title is-5"></p>
-              <p v-show="isDataCollapsed" class="is-5">
-                <span class="inline-collapsed-header"><span class="label is-small mr-1"> Name: </span>{{localDoc.name}}</span>
-                <span class="inline-collapsed-header"><span class="label is-small mr-1"> ID: </span>{{localDoc.id}}</span>
-                <span class="inline-collapsed-header"><span class="label is-small mr-1"> Tags: </span> {{localDoc.tags.join(', ')}}</span>
+              <p v-show="!isDataCollapsed"
+                 class="title is-5"></p>
+              <p v-show="isDataCollapsed"
+                 class="is-5">
+                <span class="inline-collapsed-header">
+                  <span class="label is-small mr-1">
+                    Name:
+                  </span>
+                  {{ localDoc.name }}
+                </span>
+                <span class="inline-collapsed-header">
+                  <span class="label is-small mr-1">
+                    ID:
+                  </span>
+                  {{ localDoc.id }}
+                </span>
+                <span class="inline-collapsed-header">
+                  <span class="label is-small mr-1">
+                    Tags:
+                  </span>
+                  {{ localDoc.tags.join(', ') }}
+                </span>
               </p>
             </div>
             <span v-show="isDataCollapsed">
-              <i class="fas fa-angle-down" aria-hidden="true"></i>
+              <i class="fas fa-angle-down"
+                 aria-hidden="true"></i>
             </span>
             <span v-show="!isDataCollapsed">
-              <i class="fas fa-angle-up" aria-hidden="true"></i>
+              <i class="fas fa-angle-up"
+                 aria-hidden="true"></i>
             </span>
           </div>
           <div class="content collapsible-content px-5 py-5">
             <div class="columns columns-divided">
               <div class="column is-4">
                 <div class="field">
-                <label class="label is-small">
-                  Name
-                  <span class="has-text-grey is-pulled-right document-id"
-                        title="Document id">
+                  <label class="label is-small">
+                    Name
+                    <span class="has-text-grey is-pulled-right document-id"
+                          title="Document id">
                     {{ localDoc.id }}
                   </span>
-                </label>
-                <div class="control">
-                  <input class="input is-small document-name"
-                         data-qa="security-policies-name-input"
-                         title="Document name"
-                         placeholder="Document name"
-                         @change="emitDocUpdate"
-                         v-model="localDoc.name"/>
+                  </label>
+                  <div class="control">
+                    <input class="input is-small document-name"
+                           data-qa="security-policies-name-input"
+                           title="Document name"
+                           placeholder="Document name"
+                           @change="emitDocUpdate"
+                           v-model="localDoc.name"/>
                   </div>
                 </div>
                 <div class="field">
@@ -46,22 +66,22 @@
                   </label>
                   <div class="control has-icons-left">
                     <input type="text"
-                          class="input is-small document-domain-name"
-                          data-qa="security-policies-match-input"
-                          placeholder="(api|service).company.(io|com)"
-                          @change="emitDocUpdate"
-                          @input="validateInput($event, isSelectedDomainMatchValid)"
-                          v-model="localDoc.match"
-                          :disabled="localDoc.id === '__default__'"
-                          :readonly="localDoc.id === '__default__'"
-                          title="Enter a regex to match hosts headers (domain names)">
+                           class="input is-small document-domain-name"
+                           data-qa="security-policies-match-input"
+                           placeholder="(api|service).company.(io|com)"
+                           @change="emitDocUpdate"
+                           @input="validateInput($event, isSelectedDomainMatchValid)"
+                           v-model="localDoc.match"
+                           :disabled="localDoc.id === '__default__'"
+                           :readonly="localDoc.id === '__default__'"
+                           title="Enter a regex to match hosts headers (domain names)">
                     <span class="icon is-small is-left has-text-grey"><i class="fas fa-code"></i></span>
                   </div>
                 </div>
                 <div class="field">
                   <label class="label is-small">Tags</label>
                   <div class="control"
-                      data-qa="tag-input">
+                       data-qa="tag-input">
                     <tag-autocomplete-input :initial-tag="selectedDocTags"
                                             :selection-type="'multiple'"
                                             @tag-changed="selectedDocTags = $event"/>
@@ -102,7 +122,7 @@
               </div>
               <div class="field">
                 <label class="label is-small">
-              Other Session IDs
+                  Other Session IDs
                 </label>
                 <div class="control">
                   <limit-option v-for="(option, index) in localDoc.session_ids"
@@ -110,18 +130,18 @@
                                 show-remove
                                 @remove="removeSessionId(index)"
                                 @change="updateSessionIdOption($event, index)"
-                                :removable="localDoc.session_ids.length > 1"
+                                :removable="true"
                                 :ignore-attributes="['session']"
                                 :option="generateOption(option)"
                                 :key="getOptionTextKey(option, index)"/>
                   <a title="Add new session ID"
-                    class="is-text is-small is-size-7 ml-3 add-session-id-button"
-                    data-qa="add-new-session-id-btn"
-                    tabindex="0"
-                    @click="addSessionId()"
-                    @keypress.space.prevent
-                    @keypress.space="addSessionId()"
-                    @keypress.enter="addSessionId()">
+                     class="is-text is-small is-size-7 ml-3 add-session-id-button"
+                     data-qa="add-new-session-id-btn"
+                     tabindex="0"
+                     @click="addSessionId()"
+                     @keypress.space.prevent
+                     @keypress.space="addSessionId()"
+                     @keypress.enter="addSessionId()">
                     New entry
                   </a>
                 </div>

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -81,7 +81,7 @@
           </div>
           <div class="field">
             <label class="label is-small">
-              Other Session Ids
+              Other Session IDs
             </label>
             <div class="control">
               <limit-option v-for="(option, index) in localDoc.session_ids"

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -479,6 +479,9 @@ export default defineComponent({
   watch: {
     selectedDoc: {
       handler: function(value) {
+        if (!value['session']) {
+          this.normalizeDocSession()
+        }
         if (!value['session_ids']) {
           this.normalizeDocSessionIds()
         }
@@ -515,10 +518,10 @@ export default defineComponent({
 
     sessionOption: {
       get: function(): LimitOptionType {
-        return this.generateOption(this.localDoc.session)
+        return this.generateOption(this.localDoc.session[0])
       },
-      set: function(value: SecurityPolicy['session']): void {
-        this.localDoc.session = value
+      set: function(value: LimitOptionType): void {
+        this.localDoc.session[0] = value
         this.emitDocUpdate()
       },
     },
@@ -712,6 +715,11 @@ export default defineComponent({
       }).then((response: AxiosResponse<RateLimit[]>) => {
         this.limitRuleNames = response.data
       })
+    },
+
+    normalizeDocSession() {
+      this.localDoc.session = []
+      this.emitDocUpdate()
     },
 
     normalizeDocSessionIds() {

--- a/src/doc-editors/ServerGroupsEditor.vue
+++ b/src/doc-editors/ServerGroupsEditor.vue
@@ -55,9 +55,11 @@
                     <span class="control">
                       <button class="button is-small has-text-danger delete-server-group"
                               data-qa="delete-server-group-btn"
+                              :class="{'is-loading': isDeleteLoading}"
+                              :disabled="selectedDocNotDeletable"
                               @click="toggleDeleteServerGroupDoc()">
                         <span class="icon is-small">
-                          <i  class="fas fa-trash"></i>
+                          <i class="fas fa-trash"></i>
                         </span>
                       </button>
                     </span>
@@ -93,12 +95,12 @@
                       </button>
                     </span>
                   </span>
-                </p>
-              </div>
+              </p>
             </div>
           </div>
         </div>
       </div>
+    </div>
     <hr/>
     <div class="content"
          v-if="selectedServerGroup">
@@ -420,6 +422,11 @@ export default defineComponent({
     documentAPIPath(): string {
       const apiPrefix = `${this.apiRoot}/${this.apiVersion}`
       return `${apiPrefix}/reblaze/configs/${this.selectedBranch}/d/sites/e/${this.selectedServerGroup.id}/`
+    },
+
+    selectedDocNotDeletable(): boolean {
+      return !this.selectedServerGroup ||
+          this.selectedServerGroup.id.startsWith('__') // Default entries
     },
 
     selectedSecurityPolicy(): SecurityPolicy {

--- a/src/reblaze-dashboards/DefaultDashboard.vue
+++ b/src/reblaze-dashboards/DefaultDashboard.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+  <div v-show="!loading && totalCallsInfo.amount">
     <!--First graph row-->
     <div class="columns height-300px">
       <div class="column width-200px">
@@ -231,6 +232,18 @@
                    default-sort-column-direction="desc"
                    table-title="TOP TAGS">
         </rbz-table>
+      </div>
+    </div>
+  </div>
+    <div v-show="loading || !totalCallsInfo.amount"
+         class="has-text-centered is-fullwidth">
+      <div v-if="loading">
+        <button class="button is-outlined is-text is-small is-loading dashboard-loading">
+          Loading
+        </button>
+      </div>
+      <div v-else>
+        Your search did not match any data
       </div>
     </div>
   </div>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -292,7 +292,7 @@ declare module CuriefenseClient {
   type ColumnOptions = {
     title: string
     fieldNames?: string[]
-    displayFunction?: (item: any) => string // Will be rendered as HTML
+    displayFunction?: (item: any) => string | number // Will be rendered as HTML
     isSortable?: boolean
     isSearchable?: boolean
     isNumber?: boolean // True if all values are always numbers, for sorting

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -197,7 +197,7 @@ declare module CuriefenseClient {
     match: string
     description: string
     tags: string[]
-    session: LimitOptionType
+    session: LimitOptionType[]
     session_ids: LimitOptionType[]
     map: SecurityPolicyEntryMatch[]
   }

--- a/src/views/BackendServicesList.vue
+++ b/src/views/BackendServicesList.vue
@@ -77,31 +77,24 @@ export default defineComponent({
           fieldNames: ['id'],
           isSortable: true,
           isSearchable: true,
-          classes: 'width-130px',
+          classes: 'width-130px ellipsis',
         },
         {
           title: 'Name',
           fieldNames: ['name'],
           isSortable: true,
           isSearchable: true,
-          classes: 'width-130px',
-        },
-        {
-          title: 'Description',
-          fieldNames: ['description'],
-          isSortable: true,
-          isSearchable: true,
-          classes: 'ellipsis',
+          classes: 'width-130px ellipsis',
         },
         {
           title: 'Hosts',
           fieldNames: ['back_hosts'],
           displayFunction: (item: BackendService) => {
-            return _.map(item.back_hosts, 'host')
+            return _.map(item.back_hosts, 'host').join('\n')
           },
           isSortable: true,
           isSearchable: true,
-          classes: 'width-150px',
+          classes: 'vertical-scroll white-space-pre ellipsis',
         },
         {
           title: 'Transport Protocol',
@@ -202,9 +195,13 @@ export default defineComponent({
     },
 
     async loadBackendServices() {
+      this.setLoadingDocStatus(true)
+      this.isDownloadLoading = true
       const url = `configs/${this.selectedBranch}/d/backends/`
       const response = await RequestsUtils.sendReblazeRequest({methodName: 'GET', url})
       this.backendServices = response?.data
+      this.isDownloadLoading = false
+      this.setLoadingDocStatus(false)
     },
 
     async switchBranch() {

--- a/src/views/ConfigTemplatesList.vue
+++ b/src/views/ConfigTemplatesList.vue
@@ -75,18 +75,11 @@ export default defineComponent({
           fieldNames: ['id'],
           isSortable: true,
           isSearchable: true,
-          classes: 'width-130px',
+          classes: 'width-130px ellipsis',
         },
         {
           title: 'Name',
           fieldNames: ['name'],
-          isSortable: true,
-          isSearchable: true,
-          classes: 'width-130px',
-        },
-        {
-          title: 'Description',
-          fieldNames: ['description'],
           isSortable: true,
           isSearchable: true,
           classes: 'ellipsis',
@@ -100,7 +93,7 @@ export default defineComponent({
               `<span class="width-50px is-inline-block">Burst:</span> ${item['limit_req_burst']} / second`,
             ].join('\n')
           },
-          classes: 'width-150px white-space-pre',
+          classes: 'width-200px vertical-scroll white-space-pre',
         },
         {
           title: 'Proxy Timeout',
@@ -112,7 +105,7 @@ export default defineComponent({
               `<span class="width-60px is-inline-block">Read:</span> ${item['proxy_read_timeout']}`,
             ].join('\n')
           },
-          classes: 'width-100px white-space-pre',
+          classes: 'width-150px vertical-scroll white-space-pre',
         },
       ] as ColumnOptions[],
       isNewLoading: false,
@@ -187,9 +180,13 @@ export default defineComponent({
     },
 
     async loadConfigTemplates() {
+      this.setLoadingDocStatus(true)
+      this.isDownloadLoading = true
       const url = `configs/${this.selectedBranch}/d/proxy-templates/`
       const response = await RequestsUtils.sendReblazeRequest({methodName: 'GET', url})
       this.configTemplates = response?.data
+      this.isDownloadLoading = false
+      this.setLoadingDocStatus(false)
     },
 
     async switchBranch() {

--- a/src/views/Dashboards.vue
+++ b/src/views/Dashboards.vue
@@ -68,23 +68,12 @@
           </div>
         </div>
       </div>
-      <div v-if="!data?.length"
-           class="has-text-centered is-fullwidth">
-        <div v-if="isSearchLoading">
-          <button class="button is-outlined is-text is-small is-loading dashboard-loading">
-            Loading
-          </button>
-        </div>
-        <div v-else>
-          Your search did not match any data
-        </div>
-      </div>
-      <div v-show="dashboards[activeDashboardIndex]?.useDashboard === 'default' && data?.length">
+      <div v-show="dashboards[activeDashboardIndex]?.useDashboard === 'default'">
         <rbz-dashboard-default :data="data"
                                :loading="isSearchLoading">
         </rbz-dashboard-default>
       </div>
-      <div v-show="dashboards[activeDashboardIndex]?.useDashboard === 'threats' && data?.length">
+      <div v-show="dashboards[activeDashboardIndex]?.useDashboard === 'threats'">
       </div>
     </div>
     <div v-if="dashboards[activeDashboardIndex]?.metabaseId">

--- a/src/views/DocumentEditor.vue
+++ b/src/views/DocumentEditor.vue
@@ -350,8 +350,7 @@ export default defineComponent({
           this.selectedDoc.id.startsWith('action-') || // Reblaze-managed Custom Responses
           this.selectedDoc.id.startsWith('rbz-') || // Reblaze-managed Global Filters
           this.selectedDoc.id.startsWith('dr_') || // Dynamic-Rule-managed Global Filters
-          this.isDocReferenced ||
-          this.docs.length <= 1
+          this.isDocReferenced
     },
 
     selectedDocIndex(): number {
@@ -535,7 +534,6 @@ export default defineComponent({
         await this.loadSelectedDocData()
       }
       this.setLoadingDocStatus(false)
-      this.isDownloadLoading = false
     },
 
     async switchDocID() {

--- a/src/views/DocumentList.vue
+++ b/src/views/DocumentList.vue
@@ -104,7 +104,7 @@ import {
   SecurityPolicy,
   SecurityPolicyEntryMatch,
 } from '@/types'
-import {AxiosResponse} from 'axios'
+import axios, {AxiosResponse} from 'axios'
 
 
 export default defineComponent({
@@ -142,10 +142,9 @@ export default defineComponent({
       'dynamic-rules': shallowRef({component: DynamicRulesEditor}),
     }
     return {
-      columns: [] as ColumnOptions[],
       titles: DatasetsUtils.titles,
-
       selectedDocType: null as DocumentType,
+      cancelSource: axios.CancelToken.source(),
       // Documents
       docs: [] as GenericObject[],
       docIdNames: [] as [Document['id'], Document['name']][],
@@ -203,6 +202,10 @@ export default defineComponent({
       return `configs/${this.selectedBranch}/d/${this.selectedDocType}/v/`
     },
 
+    columns(): ColumnOptions[] {
+      return this.columnOptionMap[this.selectedDocType] || []
+    },
+
     columnOptionMap() {
       return {
         'globalfilters': [
@@ -211,18 +214,11 @@ export default defineComponent({
             fieldNames: ['id'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Name',
             fieldNames: ['name'],
-            isSortable: true,
-            isSearchable: true,
-            classes: 'width-130px',
-          },
-          {
-            title: 'Description',
-            fieldNames: ['description'],
             isSortable: true,
             isSearchable: true,
             classes: 'ellipsis',
@@ -234,7 +230,7 @@ export default defineComponent({
               return item?.tags?.join('\n')
             },
             isSearchable: true,
-            classes: 'width-100px white-space-pre ellipsis',
+            classes: 'width-100px vertical-scroll white-space-pre ellipsis',
           },
           {
             title: 'Active',
@@ -266,18 +262,11 @@ export default defineComponent({
             fieldNames: ['id'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Name',
             fieldNames: ['name'],
-            isSortable: true,
-            isSearchable: true,
-            classes: 'width-130px',
-          },
-          {
-            title: 'Description',
-            fieldNames: ['description'],
             isSortable: true,
             isSearchable: true,
             classes: 'ellipsis',
@@ -290,16 +279,17 @@ export default defineComponent({
             },
             isSortable: false,
             isSearchable: true,
-            classes: 'width-100px white-space-pre ellipsis',
+            classes: 'width-100px vertical-scroll white-space-pre ellipsis',
           },
           {
             title: 'Sequences',
             fieldNames: ['sequence'],
             displayFunction: (item: FlowControlPolicy) => {
-              return item?.sequence?.length?.toString()
+              return item?.sequence?.length
             },
             isSortable: true,
             isSearchable: true,
+            isNumber: true,
             classes: 'width-100px',
           },
           {
@@ -307,6 +297,7 @@ export default defineComponent({
             fieldNames: ['timeframe'],
             isSortable: true,
             isSearchable: true,
+            isNumber: true,
             classes: 'width-100px',
           },
         ],
@@ -316,28 +307,21 @@ export default defineComponent({
             fieldNames: ['id'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Name',
             fieldNames: ['name'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
-          },
-          {
-            title: 'Description',
-            fieldNames: ['description'],
-            isSortable: true,
-            isSearchable: true,
-            classes: 'ellipsis',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Matching Names',
             fieldNames: ['match'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-150px ellipsis',
+            classes: 'ellipsis',
           },
           {
             title: 'Tags',
@@ -347,7 +331,7 @@ export default defineComponent({
             },
             isSortable: true,
             isSearchable: true,
-            classes: 'width-100px white-space-pre ellipsis',
+            classes: 'width-100px vertical-scroll white-space-pre ellipsis',
           },
           {
             title: 'Connected Profiles & Rules',
@@ -379,7 +363,7 @@ export default defineComponent({
                 getRateLimitsAmount(),
               ].join('\n')
             },
-            classes: 'width-200px white-space-pre ellipsis',
+            classes: 'width-200px vertical-scroll white-space-pre ellipsis',
           },
         ],
         'ratelimits': [
@@ -388,18 +372,11 @@ export default defineComponent({
             fieldNames: ['id'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Name',
             fieldNames: ['name'],
-            isSortable: true,
-            isSearchable: true,
-            classes: 'width-130px',
-          },
-          {
-            title: 'Description',
-            fieldNames: ['description'],
             isSortable: true,
             isSearchable: true,
             classes: 'ellipsis',
@@ -412,13 +389,14 @@ export default defineComponent({
             },
             isSortable: false,
             isSearchable: true,
-            classes: 'width-100px white-space-pre ellipsis',
+            classes: 'width-100px vertical-scroll white-space-pre ellipsis',
           },
           {
             title: 'Timeframe',
             fieldNames: ['timeframe'],
             isSortable: true,
             isSearchable: true,
+            isNumber: true,
             classes: 'width-100px',
           },
           {
@@ -436,7 +414,7 @@ export default defineComponent({
             },
             isSortable: true,
             isSearchable: true,
-            classes: 'width-250px white-space-pre ellipsis',
+            classes: 'width-250px vertical-scroll white-space-pre ellipsis',
           },
           {
             title: 'Event',
@@ -459,18 +437,11 @@ export default defineComponent({
             fieldNames: ['id'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Name',
             fieldNames: ['name'],
-            isSortable: true,
-            isSearchable: true,
-            classes: 'width-130px',
-          },
-          {
-            title: 'Description',
-            fieldNames: ['description'],
             isSortable: true,
             isSearchable: true,
             classes: 'ellipsis',
@@ -483,7 +454,7 @@ export default defineComponent({
             },
             isSortable: false,
             isSearchable: true,
-            classes: 'width-100px white-space-pre ellipsis',
+            classes: 'width-100px vertical-scroll white-space-pre ellipsis',
           },
           {
             title: 'Custom Response',
@@ -505,18 +476,11 @@ export default defineComponent({
             fieldNames: ['id'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Name',
             fieldNames: ['name'],
-            isSortable: true,
-            isSearchable: true,
-            classes: 'width-130px',
-          },
-          {
-            title: 'Description',
-            fieldNames: ['description'],
             isSortable: true,
             isSearchable: true,
             classes: 'ellipsis',
@@ -525,10 +489,11 @@ export default defineComponent({
             title: 'Status Code',
             fieldNames: ['params'],
             displayFunction: (item: CustomResponse) => {
-              return item?.params?.status?.toString() || ''
+              return item?.params?.status || null
             },
             isSortable: true,
             isSearchable: true,
+            isNumber: true,
             classes: 'width-100px white-space-pre ellipsis',
           },
           {
@@ -539,23 +504,13 @@ export default defineComponent({
             },
             isSortable: false,
             isSearchable: true,
-            classes: 'width-100px white-space-pre ellipsis',
+            classes: 'width-100px vertical-scroll white-space-pre ellipsis',
           },
           {
             title: 'Type',
             fieldNames: ['type'],
             displayFunction: (item: CustomResponse) => {
               return _.capitalize(item?.type)
-            },
-            isSortable: true,
-            isSearchable: true,
-            classes: 'width-130px',
-          },
-          {
-            title: 'Custom Response',
-            fieldNames: ['action'],
-            displayFunction: (item: CustomResponse) => {
-              return item?.tags?.join('\n')
             },
             isSortable: true,
             isSearchable: true,
@@ -568,18 +523,11 @@ export default defineComponent({
             fieldNames: ['id'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Name',
             fieldNames: ['name'],
-            isSortable: true,
-            isSearchable: true,
-            classes: 'width-130px',
-          },
-          {
-            title: 'Description',
-            fieldNames: ['description'],
             isSortable: true,
             isSearchable: true,
             classes: 'ellipsis',
@@ -592,7 +540,7 @@ export default defineComponent({
             },
             isSortable: false,
             isSearchable: true,
-            classes: 'width-100px white-space-pre ellipsis',
+            classes: 'width-100px vertical-scroll white-space-pre ellipsis',
           },
           {
             title: 'Restrict Content Type',
@@ -602,7 +550,7 @@ export default defineComponent({
             },
             isSortable: true,
             isSearchable: true,
-            classes: 'width-150px white-space-pre ellipsis',
+            classes: 'width-150px vertical-scroll white-space-pre ellipsis',
           },
           {
             title: 'Decoding',
@@ -621,7 +569,7 @@ export default defineComponent({
             },
             isSortable: true,
             isSearchable: true,
-            classes: 'width-100px white-space-pre ellipsis',
+            classes: 'width-100px vertical-scroll white-space-pre ellipsis',
           },
           {
             title: 'Custom Response',
@@ -643,18 +591,11 @@ export default defineComponent({
             fieldNames: ['id'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Name',
             fieldNames: ['name'],
-            isSortable: true,
-            isSearchable: true,
-            classes: 'width-130px',
-          },
-          {
-            title: 'Description',
-            fieldNames: ['description'],
             isSortable: true,
             isSearchable: true,
             classes: 'ellipsis',
@@ -671,13 +612,14 @@ export default defineComponent({
             fieldNames: ['subcategory'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Risk Level',
             fieldNames: ['risk'],
             isSortable: true,
             isSearchable: true,
+            isNumber: true,
             classes: 'width-100px',
           },
           {
@@ -697,18 +639,11 @@ export default defineComponent({
             fieldNames: ['id'],
             isSortable: true,
             isSearchable: true,
-            classes: 'width-130px',
+            classes: 'width-130px ellipsis',
           },
           {
             title: 'Name',
             fieldNames: ['name'],
-            isSortable: true,
-            isSearchable: true,
-            classes: 'width-150px',
-          },
-          {
-            title: 'Description',
-            fieldNames: ['description'],
             isSortable: true,
             isSearchable: true,
             classes: 'ellipsis',
@@ -766,7 +701,6 @@ export default defineComponent({
       } else {
         this.selectedDocType = Object.keys(this.componentsMap)[0] as DocumentType
       }
-      this.columns = this.columnOptionMap[this.selectedDocType]
       if (forceLoadDocs || !prevDocType || prevDocType !== this.selectedDocType) {
         await this.loadDocs()
       }
@@ -795,9 +729,23 @@ export default defineComponent({
           this.isDownloadLoading = false
         },
       })
-
       this.docs = response?.data || []
-      this.isDownloadLoading = false
+      // After we load the basic data (with x-fields) we can async load the full data for the download
+      this.cancelSource.cancel(`Operation cancelled and restarted for a new document type ${this.selectedDocType}`)
+      this.cancelSource = axios.CancelToken.source()
+      requestFunction({
+        methodName: 'GET',
+        url,
+        config: {cancelToken: this.cancelSource.token},
+        onFail: () => {
+          console.log('Error while attempting to load documents')
+          this.docs = []
+          this.isDownloadLoading = false
+        },
+      }).then((response: AxiosResponse) => {
+        this.docs = response?.data || []
+        this.isDownloadLoading = false
+      })
     },
 
     async switchBranch() {

--- a/src/views/DynamicRulesList.vue
+++ b/src/views/DynamicRulesList.vue
@@ -33,6 +33,8 @@
                    :show-filter-button="true"
                    :show-new-button="true"
                    @new-button-clicked="addNewDynamicRule"
+                   :row-clickable="true"
+                   @row-clicked="editDynamicRule"
                    :show-row-button="true"
                    @row-button-clicked="editDynamicRule">
         </rbz-table>
@@ -81,27 +83,21 @@ export default defineComponent({
           fieldNames: ['id'],
           isSortable: true,
           isSearchable: true,
-          classes: 'width-130px',
+          classes: 'width-130px ellipsis',
         },
         {
           title: 'Name',
           fieldNames: ['name'],
           isSortable: true,
           isSearchable: true,
-          classes: 'width-150px',
-        },
-        {
-          title: 'Description',
-          fieldNames: ['description'],
-          isSortable: true,
-          isSearchable: true,
-          classes: 'width-100px',
+          classes: 'ellipsis',
         },
         {
           title: 'Timeframe',
           fieldNames: ['timeframe'],
           isSortable: true,
           isSearchable: true,
+          isNumber: true,
           classes: 'width-100px',
         },
         {
@@ -109,6 +105,7 @@ export default defineComponent({
           fieldNames: ['threshold'],
           isSortable: true,
           isSearchable: true,
+          isNumber: true,
           classes: 'width-100px',
         },
         {
@@ -140,7 +137,7 @@ export default defineComponent({
           },
           isSortable: false,
           isSearchable: true,
-          classes: 'width-100px white-space-pre ellipsis',
+          classes: 'width-100px vertical-scroll white-space-pre ellipsis',
         },
       ] as ColumnOptions[],
       isNewLoading: false,
@@ -253,7 +250,6 @@ export default defineComponent({
       const response = await RequestsUtils.sendReblazeRequest({
         methodName: 'GET',
         url: url,
-        config: {headers: {'x-fields': 'id, name, description, time-frame, threshold'}},
         onFail: () => {
           console.log('Error while attempting to load documents')
           this.dynamicRulesData = []
@@ -267,7 +263,6 @@ export default defineComponent({
 
       this.dynamicRulesData.map((doc) => {
         const url = `configs/${this.selectedBranch}/d/globalfilters/e/dr_${doc.id}/`
-        // const config = {headers: {'x-fields': 'id, tags, action'}} config,
         RequestsUtils.sendRequest({methodName: 'GET', url,
           onFail: () => {
             console.log('Error while attempting to load documents')

--- a/src/views/MobileSDKsList.vue
+++ b/src/views/MobileSDKsList.vue
@@ -75,18 +75,11 @@ export default defineComponent({
           fieldNames: ['id'],
           isSortable: true,
           isSearchable: true,
-          classes: 'width-130px',
+          classes: 'width-130px ellipsis',
         },
         {
           title: 'Name',
           fieldNames: ['name'],
-          isSortable: true,
-          isSearchable: true,
-          classes: 'width-130px',
-        },
-        {
-          title: 'Description',
-          fieldNames: ['description'],
           isSortable: true,
           isSearchable: true,
           classes: 'ellipsis',
@@ -106,7 +99,7 @@ export default defineComponent({
           fieldNames: ['uid_header'],
           isSortable: true,
           isSearchable: true,
-          classes: 'width-150px',
+          classes: 'width-200px',
         },
       ] as ColumnOptions[],
       isNewLoading: false,
@@ -187,9 +180,13 @@ export default defineComponent({
     },
 
     async loadMobileSDKs() {
+      this.setLoadingDocStatus(true)
+      this.isDownloadLoading = true
       const url = `configs/${this.selectedBranch}/d/mobile-sdks/`
       const response = await RequestsUtils.sendReblazeRequest({methodName: 'GET', url})
       this.mobileSDKs = response?.data
+      this.isDownloadLoading = false
+      this.setLoadingDocStatus(false)
     },
 
     async switchBranch() {

--- a/src/views/RoutingProfilesList.vue
+++ b/src/views/RoutingProfilesList.vue
@@ -76,18 +76,11 @@ export default defineComponent({
           fieldNames: ['id'],
           isSortable: true,
           isSearchable: true,
-          classes: 'width-130px',
+          classes: 'width-130px ellipsis',
         },
         {
           title: 'Name',
           fieldNames: ['name'],
-          isSortable: true,
-          isSearchable: true,
-          classes: 'width-130px',
-        },
-        {
-          title: 'Description',
-          fieldNames: ['description'],
           isSortable: true,
           isSearchable: true,
           classes: 'ellipsis',
@@ -187,9 +180,13 @@ export default defineComponent({
     },
 
     async loadProfiles() {
+      this.setLoadingDocStatus(true)
+      this.isDownloadLoading = true
       const url = `configs/${this.selectedBranch}/d/routing-profiles/`
       const response = await RequestsUtils.sendReblazeRequest({methodName: 'GET', url})
       this.routingProfiles = response?.data
+      this.isDownloadLoading = false
+      this.setLoadingDocStatus(false)
     },
 
     async switchBranch() {

--- a/src/views/ServerGroupsList.vue
+++ b/src/views/ServerGroupsList.vue
@@ -27,16 +27,16 @@
          v-show="!loadingDocCounter && selectedBranch">
       <div class="content">
         <rbz-table :columns="columns"
-                   :data="sites"
+                   :data="serverGroups"
                    :default-sort-column-index="1"
                    :show-menu-column="true"
                    :show-filter-button="true"
                    :show-new-button="true"
-                   @new-button-clicked="addNewSite"
+                   @new-button-clicked="addNewServerGroup"
                    :row-clickable="true"
-                   @row-clicked="editSite"
+                   @row-clicked="editServerGroup"
                    :show-row-button="true"
-                   @row-button-clicked="editSite">
+                   @row-button-clicked="editServerGroup">
         </rbz-table>
         <span class="is-family-monospace has-text-grey-lighter is-inline-block mt-3">
             {{ documentListAPIPath }}
@@ -77,18 +77,11 @@ export default defineComponent({
           fieldNames: ['id'],
           isSortable: true,
           isSearchable: true,
-          classes: 'width-130px',
+          classes: 'width-130px ellipsis',
         },
         {
           title: 'Name',
           fieldNames: ['name'],
-          isSortable: true,
-          isSearchable: true,
-          classes: 'width-130px',
-        },
-        {
-          title: 'Description',
-          fieldNames: ['description'],
           isSortable: true,
           isSearchable: true,
           classes: 'ellipsis',
@@ -148,7 +141,7 @@ export default defineComponent({
       ] as ColumnOptions[],
       isNewLoading: false,
       titles: DatasetsUtils.titles,
-      sites: [],
+      serverGroups: [],
       loadingDocCounter: 0,
       isDownloadLoading: false,
       securityPoliciesNames: [] as [SecurityPolicy['id'], SecurityPolicy['name']][],
@@ -164,7 +157,7 @@ export default defineComponent({
     selectedBranch: {
       handler: function(val, oldVal) {
         if ((this.$route.name as string).includes('ServerGroups/list') && val && val !== oldVal) {
-          this.loadSites()
+          this.loadServerGroups()
           this.loadSecurityPolicies()
           this.loadRoutingProfiles()
           this.loadConfigTemplates()
@@ -197,44 +190,48 @@ export default defineComponent({
       }
     },
 
-    newSite(): Site {
+    newServerGroup(): Site {
       const factory = DatasetsUtils.newOperationEntryFactory['sites']
       return factory && factory()
     },
 
-    editSite(id: string) {
+    editServerGroup(id: string) {
       this.$router.push(`/${this.selectedBranch}/server-groups/config/${id}`)
     },
 
-    async addNewSite() {
+    async addNewServerGroup() {
       this.isNewLoading = true
-      const siteToAdd = this.newSite()
-      const siteText = this.titles['sites-singular']
-      const successMessage = `New ${siteText} was created.`
-      const failureMessage = `Failed while attempting to create the new ${siteText}.`
-      const url = `configs/${this.selectedBranch}/d/sites/e/${siteToAdd.id}`
-      const data = siteToAdd
+      const serverGroupToAdd = this.newServerGroup()
+      const serverGroupText = this.titles['sites-singular']
+      const successMessage = `New ${serverGroupText} was created.`
+      const failureMessage = `Failed while attempting to create the new ${serverGroupText}.`
+      const url = `configs/${this.selectedBranch}/d/sites/e/${serverGroupToAdd.id}`
+      const data = serverGroupToAdd
       await RequestsUtils.sendReblazeRequest({methodName: 'POST', url, data, successMessage, failureMessage})
-      this.editSite(siteToAdd.id)
+      this.editServerGroup(serverGroupToAdd.id)
       this.isNewLoading = false
     },
 
     downloadDoc() {
       if (!this.isDownloadLoading) {
-        Utils.downloadFile('sites', 'json', this.sites)
+        Utils.downloadFile('sites', 'json', this.serverGroups)
       }
     },
 
-    async loadSites() {
+    async loadServerGroups() {
+      this.setLoadingDocStatus(true)
+      this.isDownloadLoading = true
       const url = `configs/${this.selectedBranch}/d/sites/`
       const response = await RequestsUtils.sendReblazeRequest({methodName: 'GET', url})
-      this.sites = response?.data
+      this.serverGroups = response?.data
+      this.isDownloadLoading = false
+      this.setLoadingDocStatus(false)
     },
 
     async switchBranch() {
       this.setLoadingDocStatus(true)
       Utils.toast(`Switched to branch '${this.selectedBranch}'.`, 'is-info')
-      await this.loadSites()
+      await this.loadServerGroups()
       this.setLoadingDocStatus(false)
     },
 


### PR DESCRIPTION
Fix bug where `download` button would not download entire document list
Fix bug where document lists columns with numbers were sorted as strings (e.g. asc order 180->3600->60 instead of 60->180->3600)
Add vertical alignment to RbzTable data cells
Remove `Description` column from all document list views
Remove unnecessary `Custom Response` column from Custom Responses list view
Remove unnecessary complexity in LimitOption.vue
Add missing row click to Dynamic Rules table list view
Add protection too Default Dashboard to not display graphs and charts if the total number of calls is 0
Remove unnecessary code checking whether items are deletable with impossible scenarios
Remove code checking whether items are deletable if they're the last item in the document
Change Security Policy session to be array with one entry

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>