### PR TITLE
Fix various bugs

### DIFF
--- a/src/components/LimitOption.vue
+++ b/src/components/LimitOption.vue
@@ -1,90 +1,68 @@
 <template>
-  <div class="limit-options">
-    <label v-if="labelSeparatedLine && label"
-           class="label is-small is-size-7 has-text-left form-label">
-      {{ label }}
-    </label>
-    <div class="columns mb-0">
-      <div v-if="!labelSeparatedLine && label"
-           class="column is-2">
-        <label class="label is-small is-size-7 form-label">
-          {{ label }}
-        </label>
+  <div class="columns mb-0">
+    <div class="column"
+         :class="selectedTypeColumnClass">
+      <div class="control select is-small is-fullwidth">
+        <select :value="localOptionType"
+                @change="typeChanged($event)"
+                class="option-type-selection"
+                title="Type"
+                data-qa="countby-dropdown">
+          <option v-if="useDefaultSelf"
+                  value="self">
+            HTTP request
+          </option>
+          <option v-for="(value, id) in options"
+                  :data-qa="`${value}`"
+                  :value="id"
+                  :key="id">
+            {{ value }}
+          </option>
+        </select>
       </div>
-      <div class="column"
-           :class="selectedTypeColumnClass">
-        <div class="control select is-small is-fullwidth">
-          <select v-model="selectedType"
-                  class="option-type-selection"
-                  title="Type"
-                  data-qa="countby-dropdown">
-            <option v-if="useDefaultSelf"
-                    value="self">HTTP request
-            </option>
-            <option v-for="(value, id) in options"
-                    :data-qa="`${value}`"
-                    :selected="value === selectedType"
+    </div>
+    <div class="column"
+         :class="selectedNameColumnClass"
+         v-if="localOptionType !== 'self'">
+      <div v-if="isCategoryArgsCookiesHeaders(localOptionType)"
+           class="control is-fullwidth has-icons-left">
+        <input type="text"
+               title="Name"
+               :class="{ 'is-danger': localOption[this.localOptionType] === '' }"
+               v-model="localOption[this.localOptionType]"
+               @change="emitOptionUpdate"
+               class="input is-small option-name-input">
+        <span class="icon is-small is-left has-text-grey-light"><i class="fa fa-font"></i></span>
+      </div>
+      <div class="control select is-small is-fullwidth"
+           v-if="localOptionType === 'attrs'">
+        <div class="select is-fullwidth">
+          <select v-model="localOption[this.localOptionType]"
+                  @change="emitOptionUpdate"
+                  class="option-attribute-selection"
+                  title="Name"
+                  data-qa="countby-key-dropdown">
+            <option v-for="(value, id) in attributes"
                     :value="id"
-                    :key="id">
-              {{ value }}
+                    :key="id"
+                    :data-qa="value">{{ value }}
             </option>
           </select>
         </div>
       </div>
-      <div class="column"
-           :class="selectedNameColumnClass"
-           v-if="selectedType !== 'self'">
-        <div v-if="isCategoryArgsCookiesHeaders(selectedType)"
-             class="control is-fullwidth has-icons-left">
-          <input type="text"
-                 title="Name"
-                 :class="{ 'is-danger': selectedName === '' }"
-                 v-model="selectedName"
-                 class="input is-small option-name-input">
-          <span class="icon is-small is-left has-text-grey-light"><i class="fa fa-font"></i></span>
-        </div>
-        <div class="control select is-small is-fullwidth"
-             :class="selectedNameColumnClass"
-             v-if="selectedType === 'attrs'">
-          <div class="select is-fullwidth">
-            <select v-model="selectedName"
-                    class="option-attribute-selection"
-                    title="Name"
-                    data-qa="countby-key-dropdown">
-              <option v-for="(value, id) in attributes"
-                      :value="id"
-                      :key="id"
-                      :data-qa="value">{{ value }}
-              </option>
-            </select>
-          </div>
-        </div>
-      </div>
-      <div class="column"
-           :class="selectedValueColumnClass"
-           v-if="useValue">
-        <div class="control has-icons-left is-fullwidth">
-          <input type="text"
-                 title="Value"
-                 :class="{ 'is-danger': selectedValue === '' }"
-                 v-model="selectedValue"
-                 class="input is-small option-value-input">
-          <span class="icon is-small is-left has-text-grey-light"><i class="fa fa-code"></i></span>
-        </div>
-      </div>
-      <div class="column is-narrow"
-           v-if="!!showRemove">
-        <button
-            :class="removable ? 'has-text-grey' : 'has-text-grey-light is-disabled'"
-            :disabled="!removable"
-            class="button is-light is-small remove-icon remove-option-button"
-            title="Click to remove"
-            @click="$emit('remove')">
+    </div>
+    <div class="column is-narrow"
+         v-if="!!showRemove">
+      <button
+          :class="removable ? 'has-text-grey' : 'has-text-grey-light is-disabled'"
+          :disabled="!removable"
+          class="button is-light is-small remove-icon remove-option-button"
+          title="Click to remove"
+          @click="emitOptionRemove">
           <span class="icon is-small">
             <i class="fas fa-trash fa-xs"></i>
           </span>
-        </button>
-      </div>
+      </button>
     </div>
   </div>
 </template>
@@ -92,16 +70,11 @@
 <script lang="ts">
 import _ from 'lodash'
 import {defineComponent, PropType} from 'vue'
-import {LimitRuleType} from '@/types'
+import {LimitOptionType} from '@/types'
 
-export type OptionObject = {
-  type?: LimitRuleType
-  key?: string
-  value?: string
-  oldKey?: string
-}
+type LimitRuleType = 'headers' | 'args' | 'cookies' | 'attrs' | 'self'
 
-export const limitAttributes = {
+const limitAttributes = {
   authority: 'Authority',
   company: 'Company',
   country: 'Country',
@@ -123,36 +96,23 @@ export const limitAttributes = {
 export default defineComponent({
   name: 'LimitOption',
   props: {
-    label: {
-      type: String,
-      default: '',
-    },
     option: {
-      type: Object as PropType<OptionObject>,
-      default: (): OptionObject => {
+      type: Object as PropType<LimitOptionType>,
+      default: (): LimitOptionType => {
         return {
-          type: 'attrs' as OptionObject['type'],
-          key: '',
-        } as OptionObject
+          'attrs': '',
+        } as LimitOptionType
       },
-    },
-    removable: {
-      type: Boolean,
-      default: false,
     },
     showRemove: {
       type: Boolean,
       default: false,
     },
+    removable: {
+      type: Boolean,
+      default: false,
+    },
     useDefaultSelf: {
-      type: Boolean,
-      default: false,
-    },
-    useValue: {
-      type: Boolean,
-      default: false,
-    },
-    labelSeparatedLine: {
       type: Boolean,
       default: false,
     },
@@ -164,81 +124,64 @@ export default defineComponent({
     },
     selectedTypeColumnClass: String,
     selectedNameColumnClass: String,
-    selectedValueColumnClass: String,
   },
   data() {
-    const limitOptionsTypes = {
-      'headers': 'Header',
-      'cookies': 'Cookie',
-      'args': 'Argument',
-      'attrs': 'Attribute',
-    }
-    const optionsData: { [key: string]: OptionObject } = {
-      self: {
-        type: 'self',
-        key: 'self',
-      },
-    }
-    const attributes = _.pickBy(limitAttributes, (value, key) => {
-      return !this.ignoreAttributes || !this.ignoreAttributes.includes(key)
-    })
-    Object.keys(limitOptionsTypes).forEach((ruleType) => {
-      const {type, key = '', value} = this.option
-      optionsData[ruleType] = {type, key, value}
-    })
     return {
-      optionsData,
-      options: limitOptionsTypes,
-      attributes: attributes,
-      type: this.option.type || 'attrs',
-      prevSelectedOption: null as OptionObject,
+      options: {
+        'headers': 'Header',
+        'cookies': 'Cookie',
+        'args': 'Argument',
+        'attrs': 'Attribute',
+      },
     }
   },
   computed: {
-    selectedValue: {
-      get: function(): string {
-        return this.selectedOption.value
-      },
-      set: function(value: string): void {
-        this.selectedOption.value = value
-      },
+    localOption(): LimitOptionType {
+      return _.cloneDeep(this.option as LimitOptionType)
     },
-    selectedName: {
-      get: function(): string {
-        return this.selectedOption.key
-      },
-      set: function(value: string): void {
-        this.selectedOption.oldKey = this.selectedOption.key
-        this.selectedOption.key = value
-      },
+
+    localOptionType(): LimitRuleType {
+      return Object.keys(this.localOption)[0] as LimitRuleType
     },
-    selectedType: {
-      get: function(): LimitRuleType {
-        return this.selectedOption.type
-      },
-      set: function(value: LimitRuleType): void {
-        this.type = value
-        this.selectedOption.type = value
-      },
+
+    localOptionName(): string {
+      return Object.values(this.localOption)[0]
     },
-    selectedOption(): OptionObject {
-      return this.optionsData[this.type]
+
+    attributes() {
+      return _.pickBy(limitAttributes, (value, key) => {
+        return !this.ignoreAttributes || !this.ignoreAttributes.includes(key)
+      })
     },
   },
-  updated() {
-    if (!_.isEqual(this.prevSelectedOption, this.selectedOption)) {
-      this.prevSelectedOption = {...this.selectedOption}
-      this.$emit('change', {...this.selectedOption})
-    }
-  },
-  emits: ['change', 'remove'],
+  emits: ['update:option', 'remove'],
   methods: {
-    isCategoryArgsCookiesHeaders(limitRuleType: LimitRuleType) {
-      return (new RegExp('(args|cookies|headers)')).test(limitRuleType)
+    emitOptionUpdate() {
+      this.$emit('update:option', this.localOption)
     },
-  },
-  mounted() {
-    this.prevSelectedOption = {...this.selectedOption}
+
+    emitOptionRemove() {
+      this.$emit('remove')
+    },
+
+    isCategoryArgsCookiesHeaders(type: LimitRuleType) {
+      return (new RegExp('(args|cookies|headers)')).test(type)
+    },
+
+    typeChanged(event: Event) {
+      const newType: LimitRuleType = (event.target as HTMLSelectElement).value as LimitRuleType
+      delete this.localOption[this.localOptionType]
+      if (this.isCategoryArgsCookiesHeaders(newType)) {
+        this.localOption[newType] = ''
+      }
+      if (newType === 'attrs') {
+        this.localOption[newType] = 'ip'
+      }
+      if (newType === 'self') {
+        this.localOption[newType] = 'self'
+      }
+      this.emitOptionUpdate()
+    },
   },
 })
 </script>

--- a/src/components/RbzTable.vue
+++ b/src/components/RbzTable.vue
@@ -292,8 +292,13 @@ export default defineComponent({
         let sortValueA = getSortValue(a)
         let sortValueB = getSortValue(b)
         if (!this.sortColumnIsNumber) {
-          sortValueA = sortValueA.toString().toLowerCase()
-          sortValueB = sortValueB.toString().toLowerCase()
+          const sortValueALowerCase = sortValueA.toString().toLowerCase()
+          const sortValueBLowerCase = sortValueB.toString().toLowerCase()
+          // only ignore case if the values are different from one another
+          if (!_.isEqual(sortValueALowerCase, sortValueBLowerCase)) {
+            sortValueA = sortValueALowerCase
+            sortValueB = sortValueBLowerCase
+          }
         }
         if (sortValueA < sortValueB) {
           return -1 * sortModifier

--- a/src/components/__tests__/LimitOption.spec.ts
+++ b/src/components/__tests__/LimitOption.spec.ts
@@ -3,14 +3,16 @@ import LimitOption, {OptionObject} from '@/components/LimitOption.vue'
 import {beforeEach, describe, expect, test} from '@jest/globals'
 import {mount} from '@vue/test-utils'
 import {nextTick} from 'vue'
+import {LimitOptionType} from '../../types'
 
 describe('LimitOption.vue', () => {
   let option: OptionObject
   let allAttributes = []
   let wrapper: any
+  let onUpdate: any
   beforeEach(async () => {
     option = {
-      type: 'self',
+      'self': 'self',
     }
     allAttributes = [
       'Authority',
@@ -30,11 +32,14 @@ describe('LimitOption.vue', () => {
       'Tag',
       'URI',
     ]
+    onUpdate = async (option: LimitOptionType) => {
+      await wrapper.setProps({option})
+    }
     wrapper = mount(LimitOption, {
       props: {
-        option: option,
-        useDefaultSelf: true,
-        useValue: true,
+        'option': option,
+        'useDefaultSelf': true,
+        'onUpdate:option': onUpdate,
       },
     })
     await nextTick()
@@ -61,36 +66,13 @@ describe('LimitOption.vue', () => {
     expect(options.at(3).text()).toEqual('Attribute')
   })
 
-  describe('label prop', () => {
-    test('should not render label if no label provided', () => {
-      wrapper = mount(LimitOption, {
-        props: {
-          option: option,
-        },
-      })
-      const label = wrapper.find('.form-label')
-      expect(label.exists()).toBeFalsy()
-    })
-
-    test('should render label', () => {
-      const wantedLabel = 'Test'
-      wrapper = mount(LimitOption, {
-        props: {
-          option: option,
-          label: wantedLabel,
-        },
-      })
-      const label = wrapper.find('.form-label')
-      expect(label.text()).toEqual(wantedLabel)
-    })
-  })
-
   describe('showRemove prop', () => {
     test('should show button if showRemove prop is true', async () => {
       wrapper = mount(LimitOption, {
         props: {
-          option: option,
-          showRemove: true,
+          'option': option,
+          'showRemove': true,
+          'onUpdate:option': onUpdate,
         },
       })
       await nextTick()
@@ -101,8 +83,9 @@ describe('LimitOption.vue', () => {
     test('should not show button if showRemove prop is false', async () => {
       wrapper = mount(LimitOption, {
         props: {
-          option: option,
-          showRemove: false,
+          'option': option,
+          'showRemove': false,
+          'onUpdate:option': onUpdate,
         },
       })
       await nextTick()
@@ -113,7 +96,8 @@ describe('LimitOption.vue', () => {
     test('should not show button if showRemove prop does not exist', async () => {
       wrapper = mount(LimitOption, {
         props: {
-          option: option,
+          'option': option,
+          'onUpdate:option': onUpdate,
         },
       })
       await nextTick()
@@ -128,12 +112,13 @@ describe('LimitOption.vue', () => {
         return !['Tag', 'Method'].includes(item)
       })
       option = {
-        type: 'attrs',
+        'attrs': '',
       }
       wrapper = mount(LimitOption, {
         props: {
-          option: option,
-          ignoreAttributes: ['tags', 'method'],
+          'option': option,
+          'ignoreAttributes': ['tags', 'method'],
+          'onUpdate:option': onUpdate,
         },
       })
       await nextTick()
@@ -149,12 +134,13 @@ describe('LimitOption.vue', () => {
         return !['IP Address', 'URI', 'Company'].includes(item)
       })
       option = {
-        type: 'attrs',
+        'attrs': '',
       }
       wrapper = mount(LimitOption, {
         props: {
-          option: option,
-          ignoreAttributes: ['ip', 'uri', 'company'],
+          'option': option,
+          'ignoreAttributes': ['ip', 'uri', 'company'],
+          'onUpdate:option': onUpdate,
         },
       })
       await nextTick()
@@ -167,12 +153,13 @@ describe('LimitOption.vue', () => {
 
     test('should render dropdown correctly with all types if ignore is empty array', async () => {
       option = {
-        type: 'attrs',
+        'attrs': '',
       }
       wrapper = mount(LimitOption, {
         props: {
-          option: option,
-          ignoreAttributes: [],
+          'option': option,
+          'ignoreAttributes': [],
+          'onUpdate:option': onUpdate,
         },
       })
       await nextTick()
@@ -186,82 +173,61 @@ describe('LimitOption.vue', () => {
 
   describe('emit changes', () => {
     describe('type dropdown', () => {
-      test('should not emit new option when selected type selected from dropdown again', async () => {
-        const selection = wrapper.find('.option-type-selection')
-        const options = selection.findAll('option')
-        await selection.setValue(options.at(0).element.value)
-        expect(wrapper.emitted('change')).toBeFalsy()
-      })
-
       test('should emit new option when type selected from dropdown - self - headers - self', async () => {
         const wantedEmit = {
-          type: 'self',
-          key: 'self',
+          'self': 'self',
         }
         const selection = wrapper.find('.option-type-selection')
         const options = selection.findAll('option')
         // set to not self so we would be able to change to default
         await selection.setValue(options.at(1).element.value)
         await selection.setValue(options.at(0).element.value)
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
+        expect(wrapper.emitted('update:option')).toBeTruthy()
+        expect(wrapper.emitted('update:option')[1]).toEqual([wantedEmit])
       })
 
       test('should emit new option when type selected from dropdown - headers', async () => {
         const wantedEmit = {
-          type: 'headers',
-          key: '',
-          value: undefined as unknown as string,
+          'headers': '',
         }
         const selection = wrapper.find('.option-type-selection')
         const options = selection.findAll('option')
-        selection.setValue(options.at(1).element.value)
-        // options.at(1).setSelected()
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[0]).toEqual([wantedEmit])
+        await selection.setValue(options.at(1).element.value)
+        expect(wrapper.emitted('update:option')).toBeTruthy()
+        expect(wrapper.emitted('update:option')[0]).toEqual([wantedEmit])
       })
 
       test('should emit new option when type selected from dropdown - cookies', async () => {
         const wantedEmit = {
-          type: 'cookies',
-          key: '',
-          value: undefined as unknown as string,
+          'cookies': '',
         }
         const selection = wrapper.find('.option-type-selection')
         const options = selection.findAll('option')
-        options.at(2).setSelected()
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[0]).toEqual([wantedEmit])
+        await selection.setValue(options.at(2).element.value)
+        expect(wrapper.emitted('update:option')).toBeTruthy()
+        expect(wrapper.emitted('update:option')[0]).toEqual([wantedEmit])
       })
 
       test('should emit new option when type selected from dropdown - args', async () => {
         const wantedEmit = {
-          type: 'args',
-          key: '',
-          value: undefined as unknown as string,
+          'args': '',
         }
         const selection = wrapper.find('.option-type-selection')
         const options = selection.findAll('option')
-        options.at(3).setSelected()
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[0]).toEqual([wantedEmit])
+        await selection.setValue(options.at(3).element.value)
+        expect(wrapper.emitted('update:option')).toBeTruthy()
+        expect(wrapper.emitted('update:option')[0]).toEqual([wantedEmit])
       })
 
       test('should emit new option when type selected from dropdown - attrs', async () => {
         const wantedEmit = {
-          type: 'attrs',
-          key: '',
-          value: undefined as unknown as string,
+          'attrs': 'ip',
         }
         const selection = wrapper.find('.option-type-selection')
         const options = selection.findAll('option')
-        options.at(4).setSelected()
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[0]).toEqual([wantedEmit])
+        await selection.setValue(options.at(4).element.value)
+        expect(wrapper.emitted('update:option')).toBeTruthy()
+        expect(wrapper.emitted('update:option')[0]).toEqual([wantedEmit])
       })
     })
 
@@ -269,151 +235,57 @@ describe('LimitOption.vue', () => {
       test('should emit new option when key input changes - headers', async () => {
         const wantedKeyValue = 'foo'
         const wantedEmit = {
-          type: 'headers',
-          key: wantedKeyValue,
-          oldKey: '',
-          value: undefined as unknown as string,
+          'headers': wantedKeyValue,
         }
         const selection = wrapper.find('.option-type-selection')
         const options = selection.findAll('option')
-        options.at(1).setSelected()
-        await nextTick()
+        await selection.setValue(options.at(1).element.value)
         const input = wrapper.find('.option-name-input')
-        input.setValue(wantedKeyValue)
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
+        await input.setValue(wantedKeyValue)
+        expect(wrapper.emitted('update:option')).toBeTruthy()
+        expect(wrapper.emitted('update:option')[1]).toEqual([wantedEmit])
       })
 
       test('should emit new option when key selected from dropdown - cookies', async () => {
         const wantedKeyValue = 'foo'
         const wantedEmit = {
-          type: 'cookies',
-          key: wantedKeyValue,
-          oldKey: '',
-          value: undefined as unknown as string,
+          'cookies': wantedKeyValue,
         }
         const selection = wrapper.find('.option-type-selection')
         const options = selection.findAll('option')
-        options.at(2).setSelected()
-        await nextTick()
+        await selection.setValue(options.at(2).element.value)
         const input = wrapper.find('.option-name-input')
-        input.setValue(wantedKeyValue)
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
+        await input.setValue(wantedKeyValue)
+        expect(wrapper.emitted('update:option')).toBeTruthy()
+        expect(wrapper.emitted('update:option')[1]).toEqual([wantedEmit])
       })
 
       test('should emit new option when key input changes - args', async () => {
         const wantedKeyValue = 'foo'
         const wantedEmit = {
-          type: 'args',
-          key: wantedKeyValue,
-          oldKey: '',
-          value: undefined as unknown as string,
+          'args': wantedKeyValue,
         }
         const selection = wrapper.find('.option-type-selection')
         const options = selection.findAll('option')
-        options.at(3).setSelected()
-        await nextTick()
+        await selection.setValue(options.at(3).element.value)
         const input = wrapper.find('.option-name-input')
-        input.setValue(wantedKeyValue)
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
+        await input.setValue(wantedKeyValue)
+        expect(wrapper.emitted('update:option')).toBeTruthy()
+        expect(wrapper.emitted('update:option')[1]).toEqual([wantedEmit])
       })
 
       test('should emit new option when key selected from dropdown - attrs', async () => {
         const wantedEmit = {
-          type: 'attrs',
-          key: 'ip',
-          oldKey: '',
-          value: undefined as unknown as string,
+          'attrs': 'ip',
         }
         const typeSelection = wrapper.find('.option-type-selection')
         const typeOptions = typeSelection.findAll('option')
-        typeOptions.at(4).setSelected()
-        await nextTick()
+        await typeSelection.setValue(typeOptions.at(4).element.value)
         const keySelection = wrapper.find('.option-attribute-selection')
         const keyOptions = keySelection.findAll('option')
-        keyOptions.at(3).setSelected()
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
-      })
-    })
-
-    describe('value changes', () => {
-      test('should emit new option when value input changes - headers', async () => {
-        const wantedValue = 'bar'
-        const wantedEmit = {
-          type: 'headers',
-          key: '',
-          value: wantedValue,
-        }
-        const selection = wrapper.find('.option-type-selection')
-        const options = selection.findAll('option')
-        options.at(1).setSelected()
-        await nextTick()
-        const input = wrapper.find('.option-value-input')
-        input.setValue(wantedValue)
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
-      })
-
-      test('should emit new option when value selected from dropdown - cookies', async () => {
-        const wantedValue = 'bar'
-        const wantedEmit = {
-          type: 'cookies',
-          key: '',
-          value: wantedValue,
-        }
-        const selection = wrapper.find('.option-type-selection')
-        const options = selection.findAll('option')
-        options.at(2).setSelected()
-        await nextTick()
-        const input = wrapper.find('.option-value-input')
-        input.setValue(wantedValue)
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
-      })
-
-      test('should emit new option when value input changes - args', async () => {
-        const wantedValue = 'bar'
-        const wantedEmit = {
-          type: 'args',
-          key: '',
-          value: wantedValue,
-        }
-        const selection = wrapper.find('.option-type-selection')
-        const options = selection.findAll('option')
-        options.at(3).setSelected()
-        await nextTick()
-        const input = wrapper.find('.option-value-input')
-        input.setValue(wantedValue)
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
-      })
-
-      test('should emit new option when value input changes - attrs', async () => {
-        const wantedValue = 'bar'
-        const wantedEmit = {
-          type: 'attrs',
-          key: '',
-          value: wantedValue,
-        }
-        const selection = wrapper.find('.option-type-selection')
-        const options = selection.findAll('option')
-        options.at(4).setSelected()
-        await nextTick()
-        const input = wrapper.find('.option-value-input')
-        input.setValue(wantedValue)
-        await nextTick()
-        expect(wrapper.emitted('change')).toBeTruthy()
-        expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
+        await keySelection.setValue(keyOptions.at(3).element.value)
+        expect(wrapper.emitted('update:option')).toBeTruthy()
+        expect(wrapper.emitted('update:option')[1]).toEqual([wantedEmit])
       })
     })
 
@@ -422,56 +294,35 @@ describe('LimitOption.vue', () => {
         beforeEach(async () => {
           wrapper = mount(LimitOption, {
             props: {
-              option: {
-                oldKey: '',
-              },
-              useValue: true,
+              'option': {},
+              'onUpdate:option': onUpdate,
             },
           })
           await nextTick()
           const selection = wrapper.find('.option-type-selection')
           const options = selection.findAll('option')
-          options.at(2).setSelected()
+          await selection.setValue(options.at(2).element.value)
           await wrapper.vm.$forceUpdate()
         })
 
         test('should emit type change correctly', () => {
           const wantedEmit = {
-            type: 'args',
-            key: '',
-            value: undefined as unknown as string,
+            'args': '',
           }
-          expect(wrapper.emitted('change')).toBeTruthy()
-          expect(wrapper.emitted('change')[0]).toEqual([wantedEmit])
+          expect(wrapper.emitted('update:option')).toBeTruthy()
+          expect(wrapper.emitted('update:option')[0]).toEqual([wantedEmit])
         })
 
         test('should emit key change correctly', async () => {
           const wantedKeyValue = 'foo'
           const wantedEmit = {
-            type: 'args',
-            key: wantedKeyValue,
-            oldKey: '',
-            value: undefined as unknown as string,
+            'args': wantedKeyValue,
           }
           const input = wrapper.find('.option-name-input')
           input.setValue(wantedKeyValue)
           await nextTick()
-          expect(wrapper.emitted('change')).toBeTruthy()
-          expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
-        })
-
-        test('should emit value change correctly', async () => {
-          const wantedValue = 'bar'
-          const wantedEmit = {
-            type: 'args',
-            key: '',
-            value: wantedValue,
-          }
-          const input = wrapper.find('.option-value-input')
-          input.setValue(wantedValue)
-          await nextTick()
-          expect(wrapper.emitted('change')).toBeTruthy()
-          expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
+          expect(wrapper.emitted('update:option')).toBeTruthy()
+          expect(wrapper.emitted('update:option')[1]).toEqual([wantedEmit])
         })
       })
 
@@ -479,54 +330,35 @@ describe('LimitOption.vue', () => {
         beforeEach(async () => {
           wrapper = mount(LimitOption, {
             props: {
-              option: undefined,
-              useValue: true,
+              'option': undefined,
+              'onUpdate:option': onUpdate,
             },
           })
           await nextTick()
           const selection = wrapper.find('.option-type-selection')
           const options = selection.findAll('option')
-          options.at(2).setSelected()
+          await selection.setValue(options.at(2).element.value)
           await wrapper.vm.$forceUpdate()
         })
 
         test('should emit type change correctly', () => {
           const wantedEmit = {
-            type: 'args',
-            key: '',
-            value: undefined as unknown as string,
+            'args': '',
           }
-          expect(wrapper.emitted('change')).toBeTruthy()
-          expect(wrapper.emitted('change')[0]).toEqual([wantedEmit])
+          expect(wrapper.emitted('update:option')).toBeTruthy()
+          expect(wrapper.emitted('update:option')[0]).toEqual([wantedEmit])
         })
 
         test('should emit key change correctly', async () => {
           const wantedKeyValue = 'foo'
           const wantedEmit = {
-            type: 'args',
-            key: wantedKeyValue,
-            oldKey: '',
-            value: undefined as unknown as string,
+            'args': wantedKeyValue,
           }
           const input = wrapper.find('.option-name-input')
           input.setValue(wantedKeyValue)
           await nextTick()
-          expect(wrapper.emitted('change')).toBeTruthy()
-          expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
-        })
-
-        test('should emit value change correctly', async () => {
-          const wantedValue = 'bar'
-          const wantedEmit = {
-            type: 'args',
-            key: '',
-            value: wantedValue,
-          }
-          const input = wrapper.find('.option-value-input')
-          input.setValue(wantedValue)
-          await nextTick()
-          expect(wrapper.emitted('change')).toBeTruthy()
-          expect(wrapper.emitted('change')[1]).toEqual([wantedEmit])
+          expect(wrapper.emitted('update:option')).toBeTruthy()
+          expect(wrapper.emitted('update:option')[1]).toEqual([wantedEmit])
         })
       })
     })
@@ -535,9 +367,10 @@ describe('LimitOption.vue', () => {
       test('should emit remove correctly', async () => {
         wrapper = mount(LimitOption, {
           props: {
-            option: option,
-            showRemove: true,
-            removable: true,
+            'option': option,
+            'showRemove': true,
+            'removable': true,
+            'onUpdate:option': onUpdate,
           },
         })
         await nextTick()
@@ -550,9 +383,10 @@ describe('LimitOption.vue', () => {
       test('should not emit key change if removable prop is false', async () => {
         wrapper = mount(LimitOption, {
           props: {
-            option: option,
-            showRemove: true,
-            removable: false,
+            'option': option,
+            'showRemove': true,
+            'removable': false,
+            'onUpdate:option': onUpdate,
           },
         })
         await nextTick()

--- a/src/doc-editors/ACLEditor.vue
+++ b/src/doc-editors/ACLEditor.vue
@@ -209,7 +209,7 @@ export default defineComponent({
       customResponseNames: [] as [CustomResponse['id'], CustomResponse['name']][],
 
       // collapsed
-      isDataCollapsed: false,
+      isDataCollapsed: true,
     }
   },
   computed: {

--- a/src/doc-editors/FlowControlPoliciesEditor.vue
+++ b/src/doc-editors/FlowControlPoliciesEditor.vue
@@ -45,16 +45,16 @@
             </div>
           </div>
           <div class="field">
+            <label class="label is-small">
+              Count by
+            </label>
             <limit-option v-for="(option, index) in localDoc.key"
-                          label-separated-line
-                          :label="index === 0 ? 'Count by' : ''"
                           show-remove
-                          @remove="removeKey(index)"
-                          @change="updateKeyOption($event, index)"
-                          :ignore-attributes="['securitypolicyid', 'securitypolicyentryid']"
                           :removable="localDoc.key.length > 1"
-                          :index="index"
-                          :option="generateOption(option)"
+                          @remove="removeKey(index)"
+                          v-model:option="localDoc.key[index]"
+                          @update:option="emitDocUpdate(); checkKeysValidity()"
+                          :ignore-attributes="['securitypolicyid', 'securitypolicyentryid']"
                           :key="getOptionTextKey(option, index)"/>
             <a title="Add new option rule"
                class="is-text is-small is-size-7 ml-3 add-key-button"
@@ -355,7 +355,7 @@
 
 <script lang="ts">
 import _ from 'lodash'
-import LimitOption, {OptionObject} from '@/components/LimitOption.vue'
+import LimitOption from '@/components/LimitOption.vue'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import DatasetsUtils from '@/assets/DatasetsUtils'
 import {defineComponent} from 'vue'
@@ -365,7 +365,6 @@ import {
   FlowControlPolicy,
   IncludeExcludeType,
   LimitOptionType,
-  LimitRuleType,
 } from '@/types'
 import {httpRequestMethods} from '@/types/const'
 import LabeledTags from '@/components/LabeledTags.vue'
@@ -459,13 +458,6 @@ export default defineComponent({
       return `${this.localDoc.id}_${type}_${index}`
     },
 
-    generateOption(data: LimitOptionType): OptionObject {
-      const [firstObjectKey] = Object.keys(data)
-      const type = firstObjectKey as LimitRuleType
-      const key = (data[firstObjectKey] || null)
-      return {type, key, value: null}
-    },
-
     addKey() {
       this.localDoc.key.push({attrs: 'ip'})
       this.emitDocUpdate()
@@ -476,14 +468,6 @@ export default defineComponent({
       if (this.localDoc.key.length > 1) {
         this.localDoc.key.splice(index, 1)
       }
-      this.emitDocUpdate()
-      this.checkKeysValidity()
-    },
-
-    updateKeyOption(option: OptionObject, index: number) {
-      this.localDoc.key.splice(index, 1, {
-        [option.type]: option.key,
-      })
       this.emitDocUpdate()
       this.checkKeysValidity()
     },

--- a/src/doc-editors/GlobalFiltersEditor.vue
+++ b/src/doc-editors/GlobalFiltersEditor.vue
@@ -200,7 +200,7 @@ export default defineComponent({
       customResponseNames: [] as [CustomResponse['id'], CustomResponse['name']][],
 
       // collapsed
-      isDataCollapsed: false,
+      isDataCollapsed: true,
     }
   },
 

--- a/src/doc-editors/RateLimitRulesEditor.vue
+++ b/src/doc-editors/RateLimitRulesEditor.vue
@@ -77,40 +77,45 @@
             <labeled-tags title="Automatic Tags"
                           :tags="automaticTags" />
           </div>
-          <div class="group-key mb-3">
-            <limit-option v-for="(option, index) in localDoc.key"
-                          label-separated-line
-                          :label="index === 0 ? 'Count by' : ' '"
-                          show-remove
-                          @remove="removeKey(index)"
-                          @change="updateKeyOption($event, index)"
-                          :removable="localDoc.key.length > 1"
-                          :ignore-attributes="['tags']"
-                          :option="generateOption(option)"
-                          :key="getOptionTextKey(option, index)"/>
-            <a title="Add new option rule"
-               class="is-text is-small is-size-7 ml-3 add-key-button"
-               data-qa="add-new-key-btn"
-               tabindex="0"
-               @click="addKey()"
-               @keypress.space.prevent
-               @keypress.space="addKey()"
-               @keypress.enter="addKey()">
-              New entry
-            </a>
-            <p class="has-text-danger is-size-7 ml-3 mt-3 key-invalid"
-               v-if="!keysAreValid">
-              Count-by entries must be unique
-            </p>
+          <div class="field count-by-limit-option">
+            <label class="label is-small">
+              Count by
+            </label>
+            <div class="control">
+              <limit-option v-for="(option, index) in localDoc.key"
+                            show-remove
+                            :removable="localDoc.key.length > 1"
+                            @remove="removeKey(index)"
+                            v-model:option="localDoc.key[index]"
+                            @update:option="emitDocUpdate(); checkKeysValidity()"
+                            :ignore-attributes="['tags']"
+                            :key="getOptionTextKey(option, index)"/>
+              <a title="Add new option rule"
+                 class="is-text is-small is-size-7 ml-3 add-key-button"
+                 data-qa="add-new-key-btn"
+                 tabindex="0"
+                 @click="addKey()"
+                 @keypress.space.prevent
+                 @keypress.space="addKey()"
+                 @keypress.enter="addKey()">
+                New entry
+              </a>
+              <p class="has-text-danger is-size-7 ml-3 mt-3 key-invalid"
+                 v-if="!keysAreValid">
+                Count-by entries must be unique
+              </p>
+            </div>
           </div>
-          <div class="group-event mb-3">
-            <limit-option use-default-self
-                          label-separated-line
-                          label="Event"
-                          v-model:option="eventOption"
-                          :key="eventOption.type + localDoc.id"
-                          :ignore-attributes="['tags']"
-                          @change="updateEvent"/>
+          <div class="field event-limit-option">
+            <label class="label is-small">
+              Event
+            </label>
+            <div class="control">
+              <limit-option v-model:option="localDoc.pairwith"
+                            use-default-self
+                            :ignore-attributes="['tags']"
+                            @update:option="emitDocUpdate"/>
+            </div>
           </div>
           <div class="field">
             <label class="label is-small">
@@ -253,7 +258,7 @@
 
 <script lang="ts">
 import _ from 'lodash'
-import LimitOption, {OptionObject} from '@/components/LimitOption.vue'
+import LimitOption from '@/components/LimitOption.vue'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import SecurityPoliciesConnections from '@/components/SecurityPoliciesConnections.vue'
 import {defineComponent} from 'vue'
@@ -262,7 +267,6 @@ import {
   Dictionary,
   IncludeExcludeType,
   LimitOptionType,
-  LimitRuleType,
   RateLimit,
   ThresholdActionPair,
 } from '@/types'
@@ -326,16 +330,6 @@ export default defineComponent({
       const dupTags = _.filter(allTags, (val, i, iteratee) => _.includes(iteratee, val, i + 1))
       return _.fromPairs(_.zip(dupTags, dupTags))
     },
-
-    eventOption: {
-      get: function(): LimitOptionType {
-        return this.generateOption(this.localDoc.pairwith)
-      },
-      set: function(value: RateLimit['pairwith']): void {
-        this.localDoc.pairwith = value
-        this.emitDocUpdate()
-      },
-    },
   },
   emits: ['update:selectedDoc', 'go-to-route'],
   methods: {
@@ -352,16 +346,6 @@ export default defineComponent({
       }
       const [type] = Object.keys(option)
       return `${this.localDoc.id}_${type}_${index}`
-    },
-
-    generateOption(data: LimitOptionType): OptionObject {
-      if (!data) {
-        return {}
-      }
-      const [firstObjectKey] = Object.keys(data)
-      const type = firstObjectKey as LimitRuleType
-      const key = data[firstObjectKey]
-      return {type, key, value: null}
     },
 
     addThreshold() {
@@ -390,14 +374,6 @@ export default defineComponent({
       this.checkKeysValidity()
     },
 
-    updateKeyOption(option: OptionObject, index: number) {
-      this.localDoc.key.splice(index, 1, {
-        [option.type]: option.key,
-      })
-      this.emitDocUpdate()
-      this.checkKeysValidity()
-    },
-
     checkKeysValidity() {
       const keysToCheck = _.countBy(this.localDoc.key, (item) => {
         if (!item) {
@@ -414,10 +390,6 @@ export default defineComponent({
         }
       }
       return this.keysAreValid
-    },
-
-    updateEvent(option: OptionObject) {
-      this.eventOption = {[option.type]: option.key}
     },
 
     addNewTag(section: IncludeExcludeType, entry: string) {

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -517,7 +517,7 @@ export default defineComponent({
       matchingDomainTitle: 'A unique matching regex value, not overlapping other Security Policy definitions',
 
       // collapsed
-      isDataCollapsed: false,
+      isDataCollapsed: true,
     }
   },
 

--- a/src/doc-editors/SecurityPoliciesEditor.vue
+++ b/src/doc-editors/SecurityPoliciesEditor.vue
@@ -106,44 +106,43 @@
                   </div>
                 </div>
               </div>
-            </div>
-            <div class="column is-8">
-              <div class="field">
-                <label class="label is-small">
-                  Main Session ID
-                </label>
-                <div class="control">
-                  <limit-option selected-type-column-class="is-3"
-                                v-model:option="sessionOption"
-                                :key="sessionOption.type + localDoc.id"
-                                :ignore-attributes="['session']"
-                                @change="emitDocUpdate"/>
+              <div class="column is-8">
+                <div class="field">
+                  <label class="label is-small">
+                    Main Session ID
+                  </label>
+                  <div class="control">
+                    <limit-option selected-type-column-class="is-3"
+                                  v-model:option="localDoc.session[0]"
+                                  :ignore-attributes="['session']"
+                                  @update:option="emitDocUpdate"/>
+                  </div>
                 </div>
-              </div>
-              <div class="field">
-                <label class="label is-small">
-                  Other Session IDs
-                </label>
-                <div class="control">
-                  <limit-option v-for="(option, index) in localDoc.session_ids"
-                                selected-type-column-class="is-3"
-                                show-remove
-                                @remove="removeSessionId(index)"
-                                @change="updateSessionIdOption($event, index)"
-                                :removable="true"
-                                :ignore-attributes="['session']"
-                                :option="generateOption(option)"
-                                :key="getOptionTextKey(option, index)"/>
-                  <a title="Add new session ID"
-                     class="is-text is-small is-size-7 ml-3 add-session-id-button"
-                     data-qa="add-new-session-id-btn"
-                     tabindex="0"
-                     @click="addSessionId()"
-                     @keypress.space.prevent
-                     @keypress.space="addSessionId()"
-                     @keypress.enter="addSessionId()">
-                    New entry
-                  </a>
+                <div class="field">
+                  <label class="label is-small">
+                    Other Session IDs
+                  </label>
+                  <div class="control">
+                    <limit-option v-for="(option, index) in localDoc.session_ids"
+                                  selected-type-column-class="is-3"
+                                  show-remove
+                                  removable
+                                  @remove="removeSessionId(index)"
+                                  @update:option="emitDocUpdate"
+                                  :ignore-attributes="['session']"
+                                  v-model:option="localDoc.session_ids[index]"
+                                  :key="getOptionTextKey(option, index)"/>
+                    <a title="Add new session ID"
+                       class="is-text is-small is-size-7 ml-3 add-session-id-button"
+                       data-qa="add-new-session-id-btn"
+                       tabindex="0"
+                       @click="addSessionId()"
+                       @keypress.space.prevent
+                       @keypress.space="addSessionId()"
+                       @keypress.enter="addSessionId()">
+                      New entry
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>
@@ -475,7 +474,6 @@ import {
   ACLProfile,
   ContentFilterProfile,
   LimitOptionType,
-  LimitRuleType,
   RateLimit,
   SecurityPolicy,
   SecurityPolicyEntryMatch,
@@ -484,7 +482,7 @@ import {AxiosResponse} from 'axios'
 import Utils from '@/assets/Utils'
 import TagAutocompleteInput from '@/components/TagAutocompleteInput.vue'
 import LabeledTags from '@/components/LabeledTags.vue'
-import LimitOption, {OptionObject} from '@/components/LimitOption.vue'
+import LimitOption from '@/components/LimitOption.vue'
 
 export default defineComponent({
   name: 'SecurityPoliciesEditor',
@@ -561,16 +559,6 @@ export default defineComponent({
     automaticTags(): string[] {
       const nameTag = `securitypolicy:${this.localDoc.name?.replace(/ /g, '-') || ''}`
       return [nameTag]
-    },
-
-    sessionOption: {
-      get: function(): LimitOptionType {
-        return this.generateOption(this.localDoc.session[0])
-      },
-      set: function(value: LimitOptionType): void {
-        this.localDoc.session[0] = value
-        this.emitDocUpdate()
-      },
     },
 
     isFormInvalid(): boolean {
@@ -764,7 +752,7 @@ export default defineComponent({
     },
 
     normalizeDocSession() {
-      this.localDoc.session = []
+      this.localDoc.session = [{'attrs': ''}]
       this.emitDocUpdate()
     },
 
@@ -781,32 +769,13 @@ export default defineComponent({
       return `${this.localDoc.id}_${type}_${index}`
     },
 
-    generateOption(data: LimitOptionType): OptionObject {
-      if (!data) {
-        return {}
-      }
-      const [firstObjectKey] = Object.keys(data)
-      const type = firstObjectKey as LimitRuleType
-      const key = data[firstObjectKey]
-      return {type, key, value: null}
-    },
-
     addSessionId() {
       this.localDoc.session_ids.push({attrs: 'ip'})
       this.emitDocUpdate()
     },
 
     removeSessionId(index: number) {
-      if (this.localDoc.session_ids.length > 1) {
-        this.localDoc.session_ids.splice(index, 1)
-      }
-      this.emitDocUpdate()
-    },
-
-    updateSessionIdOption(option: OptionObject, index: number) {
-      this.localDoc.session_ids.splice(index, 1, {
-        [option.type]: option.key,
-      })
+      this.localDoc.session_ids.splice(index, 1)
       this.emitDocUpdate()
     },
   },

--- a/src/doc-editors/__tests__/FlowControlPolicyEditor.spec.ts
+++ b/src/doc-editors/__tests__/FlowControlPolicyEditor.spec.ts
@@ -85,13 +85,10 @@ describe('FlowControlPoliciesEditor.vue', () => {
     })
 
     test('should have limit option component with correct data', () => {
-      const wantedType = Object.keys(docs[0].key[0])[0]
-      const wantedValue = Object.values(docs[0].key[0])[0]
+      const wantedOption = docs[0].key[0]
       const limitOptionComponent = wrapper.findAllComponents(LimitOption).at(0)
-      const actualType = limitOptionComponent.vm.option.type
-      const actualValue = limitOptionComponent.vm.option.key
-      expect(actualType).toEqual(wantedType)
-      expect(actualValue).toEqual(wantedValue)
+      const actualOption = limitOptionComponent.vm.option
+      expect(actualOption).toEqual(wantedOption)
     })
 
     test('should have correct description in input', () => {
@@ -165,15 +162,11 @@ describe('FlowControlPoliciesEditor.vue', () => {
     })
 
     test('should update key when change event occurs', async () => {
-      const newOption = {
-        type: 'self',
-        key: 'self',
-      }
       const wantedResult = {
-        self: 'self',
+        'self': 'self',
       }
       const limitOptionsComponent = wrapper.findComponent(LimitOption)
-      await limitOptionsComponent.vm.$emit('change', newOption, 0)
+      await limitOptionsComponent.vm.$emit('update:option', wantedResult, 0)
       expect(wrapper.vm.localDoc.key[0]).toEqual(wantedResult)
     })
   })

--- a/src/doc-editors/__tests__/RateLimitsEditor.spec.ts
+++ b/src/doc-editors/__tests__/RateLimitsEditor.spec.ts
@@ -150,44 +150,41 @@ describe('RateLimitRulesEditor.vue', () => {
     })
 
     test('should have count-by limit option component with correct data', () => {
-      const wantedType = Object.keys(rateLimitsDocs[0].key[0])[0]
-      const wantedValue = Object.values(rateLimitsDocs[0].key[0])[0]
-      const limitOptionComponent = wrapper.findComponent(LimitOption)
-      const actualType = limitOptionComponent.vm.option.type
-      const actualValue = limitOptionComponent.vm.option.key
-      expect(actualType).toEqual(wantedType)
-      expect(actualValue).toEqual(wantedValue)
+      const wantedOption = rateLimitsDocs[0].key[0]
+      const limitOptionElement = wrapper.find('.count-by-limit-option')
+      const limitOptionComponent = limitOptionElement.findAllComponents(LimitOption).at(0)
+      const actualOption = limitOptionComponent.vm.option
+      expect(actualOption).toEqual(wantedOption)
     })
 
     test('should have event limit option component with correct data', () => {
-      const wantedType = Object.keys(rateLimitsDocs[0].pairwith)[0]
-      const wantedValue = Object.values(rateLimitsDocs[0].pairwith)[0]
-      const actualType = wrapper.vm.eventOption.type
-      const actualValue = wrapper.vm.eventOption.key
-      expect(actualValue).toEqual(wantedValue)
-      expect(actualType).toEqual(wantedType)
+      const wantedOption = rateLimitsDocs[0].pairwith
+      const limitOptionElement = wrapper.find('.event-limit-option')
+      const limitOptionComponent = limitOptionElement.findAllComponents(LimitOption).at(0)
+      const actualOption = limitOptionComponent.vm.option
+      expect(actualOption).toEqual(wantedOption)
     })
 
     test('should have limit option keys with correct data', () => {
-      const wantedType = Object.keys(rateLimitsDocs[0].key[0])[0]
-      const wantedValue = Object.values(rateLimitsDocs[0].key[0])[0]
-      const limitOptionComponent = wrapper.findComponent(LimitOption)
-      const actualType = limitOptionComponent.vm.option.type
-      const actualValue = limitOptionComponent.vm.option.key
-      expect(actualType).toEqual(wantedType)
-      expect(actualValue).toEqual(wantedValue)
+      const wantedOption = rateLimitsDocs[0].key[0]
+      const limitOptionElement = wrapper.find('.count-by-limit-option')
+      const limitOptionComponent = limitOptionElement.findAllComponents(LimitOption).at(0)
+      const actualOption = limitOptionComponent.vm.option
+      expect(actualOption).toEqual(wantedOption)
     })
 
     test('should have count-by limit option component with correct ignored attributes', () => {
       const wantedIgnoredAttributes = ['tags']
-      const limitOptionComponent = wrapper.findComponent(LimitOption)
+      const limitOptionElement = wrapper.find('.count-by-limit-option')
+      const limitOptionComponent = limitOptionElement.findComponent(LimitOption)
       const actualIgnoredAttributes = limitOptionComponent.vm.ignoreAttributes
       expect(wantedIgnoredAttributes).toEqual(actualIgnoredAttributes)
     })
 
     test('should have event limit option component with correct ignored attributes', () => {
       const wantedIgnoredAttributes = ['tags']
-      const limitOptionComponent = wrapper.findComponent(LimitOption)
+      const limitOptionElement = wrapper.find('.event-limit-option')
+      const limitOptionComponent = limitOptionElement.findComponent(LimitOption)
       const actualIgnoredAttributes = limitOptionComponent.vm.ignoreAttributes
       expect(wantedIgnoredAttributes).toEqual(actualIgnoredAttributes)
     })
@@ -252,18 +249,20 @@ describe('RateLimitRulesEditor.vue', () => {
     })
 
     test('should remove key when remove event occurs', async () => {
-      expect(wrapper.vm.localDoc.key.length).toEqual(3) // default has 3 atributes keys
+      expect(wrapper.vm.localDoc.key.length).toEqual(3) // default has 3 attributes keys
       const addKeyButton = wrapper.find('.add-key-button')
       await addKeyButton.trigger('click')
       expect(wrapper.vm.localDoc.key.length).toEqual(4) // plus 1 = 4
-      const limitOptionsComponent = wrapper.findComponent(LimitOption)
+      const limitOptionElement = wrapper.find('.count-by-limit-option')
+      const limitOptionsComponent = limitOptionElement.findComponent(LimitOption)
       limitOptionsComponent.vm.$emit('remove', 1)
       expect(wrapper.vm.localDoc.key.length).toEqual(3) // minus 1 = 3
     })
 
     test('should not be able to remove key when only one key exists', () => {
-      expect(wrapper.vm.localDoc.key.length).toEqual(3) // default has 3 atributes keys
-      const limitOptionsComponent = wrapper.findComponent(LimitOption)
+      expect(wrapper.vm.localDoc.key.length).toEqual(3) // default has 3 attributes keys
+      const limitOptionElement = wrapper.find('.count-by-limit-option')
+      const limitOptionsComponent = limitOptionElement.findComponent(LimitOption)
       limitOptionsComponent.vm.$emit('remove', 1)
       limitOptionsComponent.vm.$emit('remove', 1)
       expect(wrapper.vm.localDoc.key.length).toEqual(1) // remove 2 remain 1
@@ -272,15 +271,12 @@ describe('RateLimitRulesEditor.vue', () => {
     })
 
     test('should update key when change event occurs', async () => {
-      const newOption = {
-        type: 'self',
-        key: 'self',
-      }
       const wantedResult = {
-        self: 'self',
+        'self': 'self',
       }
-      const limitOptionsComponent = wrapper.findComponent(LimitOption)
-      limitOptionsComponent.vm.$emit('change', newOption, 0)
+      const limitOptionElement = wrapper.find('.count-by-limit-option')
+      const limitOptionsComponent = limitOptionElement.findComponent(LimitOption)
+      limitOptionsComponent.vm.$emit('update:option', wantedResult, 0)
       expect(wrapper.vm.localDoc.key[0]).toEqual(wantedResult)
     })
 
@@ -292,7 +288,6 @@ describe('RateLimitRulesEditor.vue', () => {
             selectedDoc: rateLimitsDocs[0],
           },
         })
-        // zawait nextTick()
       } catch (err) {
         // should not get here
         expect(err).not.toBeDefined()
@@ -346,15 +341,11 @@ describe('RateLimitRulesEditor.vue', () => {
     })
 
     test('should update key when change event occurs', async () => {
-      const newOption = {
-        type: 'self',
-        key: 'self',
-      }
       const wantedResult = {
-        self: 'self',
+        'self': 'self',
       }
       const limitOptionsComponent = wrapper.findAllComponents(LimitOption).at(1)
-      limitOptionsComponent.vm.$emit('change', newOption, 0)
+      limitOptionsComponent.vm.$emit('update:option', wantedResult, 0)
       expect(wrapper.vm.localDoc.pairwith).toEqual(wantedResult)
     })
 
@@ -366,7 +357,6 @@ describe('RateLimitRulesEditor.vue', () => {
             selectedDoc: rateLimitsDocs[0],
           },
         })
-        // await nextTick()
       } catch (err) {
         // Should not get here
         expect(err).not.toBeDefined()
@@ -599,8 +589,8 @@ describe('RateLimitRulesEditor.vue', () => {
 
     test('should send request to change Security Policy when removing connection was confirmed', async () => {
       const putSpy = jest.spyOn(axios, 'put').mockImplementation(() => Promise.resolve())
-      // eslint-disable-next-line max-len
-      const wantedUrl = `/conf/api/v3/configs/${wrapper.vm.selectedBranch}/d/securitypolicies/e/${securityPoliciesDocs[0].id}/`
+      const selectedBranch = wrapper.vm.selectedBranch
+      const wantedUrl = `/conf/api/v3/configs/${selectedBranch}/d/securitypolicies/e/${securityPoliciesDocs[0].id}/`
       const wantedDoc = JSON.parse(JSON.stringify(securityPoliciesDocs[0]))
       wantedDoc.map[0].limit_ids = []
       const removeConnectionButton = wrapper.findAll('.remove-connection-button').at(0)

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -95,8 +95,6 @@ declare module CuriefenseClient {
 
   type ArgsCookiesHeadersType = 'headers' | 'args' | 'cookies'
 
-  type LimitRuleType = 'headers' | 'args' | 'cookies' | 'attrs' | 'self'
-
   type DynamicRuleTargetOptionType =
     'remote_addr'
     | 'organization'

--- a/src/views/DocumentEditor.vue
+++ b/src/views/DocumentEditor.vue
@@ -26,10 +26,10 @@
                           @change="switchDocID()"
                           class="doc-selection"
                           data-qa="switch-document">
-                    <option v-for="pair in docIdNames"
-                            :key="pair[0]"
-                            :value="pair[0]">
-                      {{ pair[1] }}
+                    <option v-for="doc in docIdNames"
+                            :key="doc.id"
+                            :value="doc.id">
+                      {{ doc.name }}
                     </option>
                   </select>
                 </div>
@@ -163,7 +163,7 @@
           <span v-if="!Object.keys(componentsMap).includes(selectedDocType)">
             Missing document type. Please check your URL or click a link in the menu to the side
           </span>
-          <span v-else-if="!docIdNames.find((docIdName) => docIdName[0].includes(selectedDoc?.id))">
+          <span v-else-if="!docIdNames.find((doc) => doc.id.includes(selectedDoc?.id))">
             Missing document. To create a new one, click
             <a title="Add new"
                @click="addNewDoc()">
@@ -247,7 +247,7 @@ export default defineComponent({
       selectedDocType: null as DocumentType,
 
       docs: [] as Document[],
-      docIdNames: [] as [Document['id'], Document['name']][],
+      docIdNames: [] as Document[],
       selectedDocID: null,
       cancelSource: axios.CancelToken.source(),
       isDownloadLoading: false,
@@ -422,10 +422,10 @@ export default defineComponent({
         await this.loadDocs()
       }
       const docIdFromRoute = this.$route.params?.doc_id?.toString()
-      if (docIdFromRoute && this.docIdNames.findIndex((idName) => idName[0] === docIdFromRoute) > -1) {
+      if (docIdFromRoute && this.docIdNames.findIndex((doc) => doc.id === docIdFromRoute) > -1) {
         this.selectedDocID = docIdFromRoute
       } else {
-        this.selectedDocID = this.docIdNames?.[0]?.[0]
+        this.selectedDocID = this.docIdNames?.[0]?.id
       }
       this.isDocumentInvalid = false
 
@@ -448,11 +448,24 @@ export default defineComponent({
     },
 
     updateDocIdNames() {
-      this.docIdNames = _.sortBy(_.map(this.docs, (doc) => {
-        return [doc.id, doc.name]
-      }), (entry) => {
-        return entry[1].toLowerCase()
-      })
+      this.docIdNames = _.sortBy(this.docs, (a: Document, b: Document) => {
+        let sortValueA: string = a.name
+        let sortValueB: string = b.name
+        const sortValueALowerCase: string = sortValueA.toString().toLowerCase()
+        const sortValueBLowerCase: string = sortValueB.toString().toLowerCase()
+        // only ignore case if the values are different from one another
+        if (!_.isEqual(sortValueALowerCase, sortValueBLowerCase)) {
+          sortValueA = sortValueALowerCase
+          sortValueB = sortValueBLowerCase
+        }
+        if (sortValueA < sortValueB) {
+          return -1
+        }
+        if (sortValueA > sortValueB) {
+          return 1
+        }
+        return 0
+      }) as Document[]
     },
 
     async loadSelectedDocData() {
@@ -525,11 +538,11 @@ export default defineComponent({
         this.isDownloadLoading = false
       })
       this.updateDocIdNames()
-      if (this.docIdNames && this.docIdNames.length && this.docIdNames[0].length) {
-        if (!skipDocSelection || !_.find(this.docIdNames, (idName: [Document['id'], Document['name']]) => {
-          return idName[0] === this.selectedDocID
+      if (this.docIdNames && this.docIdNames.length && this.docIdNames[0].id) {
+        if (!skipDocSelection || !_.find(this.docIdNames, (doc: Document) => {
+          return doc.id === this.selectedDocID
         })) {
-          this.selectedDocID = this.docIdNames[0][0]
+          this.selectedDocID = this.docIdNames[0].id
         }
         await this.loadSelectedDocData()
       }
@@ -682,9 +695,7 @@ export default defineComponent({
         })
       }
 
-      this.selectedDocID = this.docs[0].id
-      await this.loadSelectedDocData()
-      this.goToRoute()
+      this.redirectToList()
       this.isDeleteLoading = false
       this.setLoadingDocStatus(false)
     },

--- a/src/views/DocumentList.vue
+++ b/src/views/DocumentList.vue
@@ -147,7 +147,6 @@ export default defineComponent({
       cancelSource: axios.CancelToken.source(),
       // Documents
       docs: [] as GenericObject[],
-      docIdNames: [] as [Document['id'], Document['name']][],
       // To prevent deletion of docs referenced by Security Policies
       referencedIDsACL: [],
       referencedIDsContentFilter: [],

--- a/src/views/DynamicRulesList.vue
+++ b/src/views/DynamicRulesList.vue
@@ -222,6 +222,7 @@ export default defineComponent({
       docMatchingGlobalFilter.id = `dr_${docToAdd.id}`
       docMatchingGlobalFilter.active = (docToAdd as DynamicRule).active
       docMatchingGlobalFilter.name = 'Global Filter for Dynamic Rule ' + docToAdd.id
+      docMatchingGlobalFilter.action = 'action-dynamic-rule-block'
       const globalFiltersData = docMatchingGlobalFilter
       const globalFiltersUrl = `configs/${this.selectedBranch}/d/globalfilters/e/`
       await RequestsUtils.sendRequest({methodName: 'POST', url: globalFiltersUrl, data: globalFiltersData})


### PR DESCRIPTION
Fix bug LimitOption.vue where data did not update properly on prop change
Fix bug in LimitOption.vue where data did not reset properly on type change through dropdown
Remove unused code in LimitOption.vue
Fix bug in Security Policy where last `Additional Session IDs` could not be deleted
Fix merge issue with location of `Main Session ID` and `Additional Session IDs` in Security Policy editor
Change redirect from Document Editor after delete to list page instead of first document of the current type
Fix issue with new Dynamic Rule using Global Filter action (Creation from list. Creation from editor was already solved in a recent patch)
Fix order of documents in dropdown to be consistent with the order in the list view table
Change default collapse data state in ACL Profile, Global Filter, and Security Policy to be collapsed

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>