### PR TITLE
Changes according to new schemas in saas backend

### DIFF
--- a/src/assets/DatasetsUtils.ts
+++ b/src/assets/DatasetsUtils.ts
@@ -377,12 +377,8 @@ const newOperationEntryFactory: { [key: string]: Function } = {
       'id': generateUUID2(),
       'name': 'New Mobile SDK ' + generateUUID2(), // TODO: Remove this random uuid once names are no longer unique
       'description': 'New Mobile SDK Description and Remarks',
-      'secret': '',
-      'var_name': '',
       'uid_header': 'authorization',
       'grace': '5',
-      'grace_var_name': '',
-      'validator_type': '',
       'active_config': [
         {
           'active': true,
@@ -391,7 +387,6 @@ const newOperationEntryFactory: { [key: string]: Function } = {
         },
       ],
       'signatures': [],
-      'support_legacy_sdk': false,
     }
   },
 
@@ -405,7 +400,7 @@ const newOperationEntryFactory: { [key: string]: Function } = {
       'client_body_timeout': '5',
       'client_header_timeout': '5',
       'client_max_body_size': '150',
-      'conf_specific': {'value': ''},
+      'conf_specific': '',
       'custom_listener': false,
       'keepalive_timeout': '660',
       'limit_req_rate': '1200',
@@ -415,7 +410,7 @@ const newOperationEntryFactory: { [key: string]: Function } = {
       'proxy_read_timeout': '60',
       'proxy_send_timeout': '30',
       'send_timeout': '5',
-      'ssl_conf_specific': {'value': ''},
+      'ssl_conf_specific': '',
       'upstream_host': '$host',
       'xff_header_name': 'X-Forwarded-For',
       'xrealip_header_name': 'X-Real-IP',
@@ -436,7 +431,7 @@ const newOperationEntryFactory: { [key: string]: Function } = {
         'http_port': 80,
         'https_port': 443,
         'weight': 1,
-        'fail_timeout': '10s',
+        'fail_timeout': 10,
         'monitor_state': '',
         'down': false,
         'host': '127.0.0.1',

--- a/src/doc-editors/BackendServicesEditor.vue
+++ b/src/doc-editors/BackendServicesEditor.vue
@@ -363,7 +363,7 @@ export default defineComponent({
         http_port: 80,
         https_port: 443,
         weight: 1,
-        fail_timeout: '10s',
+        fail_timeout: 10,
         down: false,
         host: '',
         max_fails: 0,

--- a/src/doc-editors/ProxyTemplatesEditor.vue
+++ b/src/doc-editors/ProxyTemplatesEditor.vue
@@ -492,13 +492,13 @@
               <p class="title is-5 is-uppercase">Advanced Settings</p>
             </div>
             <span v-show="isAdvancedCollapsed">
-                    <i class="fas fa-angle-down"
-                       aria-hidden="true"></i>
-                  </span>
+              <i class="fas fa-angle-down"
+                 aria-hidden="true"></i>
+            </span>
             <span v-show="!isAdvancedCollapsed">
-                    <i class="fas fa-angle-up"
-                       aria-hidden="true"></i>
-                  </span>
+              <i class="fas fa-angle-up"
+                 aria-hidden="true"></i>
+            </span>
           </div>
           <div class="content collapsible-content px-5 py-5">
             <div class="columns">
@@ -509,28 +509,32 @@
                       HTTP Listener Custom Configuration
                     </label>
                     <div class="control">
-                            <textarea
-                                rows="5"
+                      <textarea rows="5"
                                 class="is-small textarea site-conf"
-                                v-model="selectedProxyTemplate.conf_specific.value">
-                            </textarea>
+                                v-model="selectedProxyTemplate.conf_specific">
+                      </textarea>
                     </div>
-                    <p class="help has-text-danger">Unless instructed, don't touch!</p>
+                    <p class="help has-text-danger">
+                      Unless instructed, don't touch!
+                    </p>
                   </div>
                 </div>
               </div>
               <div class="column is-6">
                 <div class="field ">
                   <div class="field">
-                    <label class="label is-small">HTTPS Listener Custom Configuration</label>
+                    <label class="label is-small">
+                      HTTPS Listener Custom Configuration
+                    </label>
                     <div class="control">
-                            <textarea
-                                rows="5"
+                      <textarea rows="5"
                                 class="is-small textarea site-ssl-conf"
-                                v-model="selectedProxyTemplate.ssl_conf_specific.value">
-                            </textarea>
+                                v-model="selectedProxyTemplate.ssl_conf_specific">
+                      </textarea>
                     </div>
-                    <p class="help has-text-danger">Unless instructed, don't touch!</p>
+                    <p class="help has-text-danger">
+                      Unless instructed, don't touch!
+                    </p>
                   </div>
                 </div>
               </div>
@@ -876,12 +880,6 @@ export default defineComponent({
         },
       })
       this.selectedProxyTemplate = response?.data || {}
-      if (!this.selectedProxyTemplate.conf_specific) {
-        this.selectedProxyTemplate.conf_specific = {value: ''}
-      }
-      if (!this.selectedProxyTemplate.ssl_conf_specific) {
-        this.selectedProxyTemplate.ssl_conf_specific = {value: ''}
-      }
       this.isDownloadLoading = false
       this.setLoadingDocStatus(false)
     },

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -309,7 +309,7 @@ declare module CuriefenseClient {
       http_port: number
       https_port: number
       weight: number
-      fail_timeout: string
+      fail_timeout: number
       monitor_state: string
       down: boolean
       host: string
@@ -367,15 +367,10 @@ declare module CuriefenseClient {
     id: string
     name: string
     description: string
-    secret: string
-    var_name: string
     uid_header: string
     grace: string
-    grace_var_name: string
-    validator_type: string
     active_config: MobileSDKConfig[]
     signatures: MobileSDKSignature[]
-    support_legacy_sdk: boolean
   }
 
   type ProxyTemplate = {
@@ -386,7 +381,7 @@ declare module CuriefenseClient {
     client_body_timeout: string
     client_header_timeout: string
     client_max_body_size: string
-    conf_specific: {value: string}
+    conf_specific: string
     custom_listener: boolean
     keepalive_timeout: string
     limit_req_rate: string
@@ -396,7 +391,7 @@ declare module CuriefenseClient {
     proxy_read_timeout: string
     proxy_send_timeout: string
     send_timeout: string
-    ssl_conf_specific: {value: string}
+    ssl_conf_specific: string
     upstream_host: string
     xff_header_name: string
     xrealip_header_name: string


### PR DESCRIPTION
Change ssl_conf_specific and conf_specific to string in Proxy Templates
Change fail_timeout to number in Backend Services
Remove secret, support_legacy_sdk, grace_var_name, var_name, validator_type in Mobile SDKs

Signed-off-by: Aviv.Galmidi <AvivGalmidi@gmail.com>