### PR TITLE
Events Log changes

### DIFF
--- a/src/assets/styles/colors.scss
+++ b/src/assets/styles/colors.scss
@@ -4,6 +4,8 @@ Names taken from this site: https://chir.ag/projects/name-that-color
 Names are the solid (exact) versions of these colors
 */
 
+$color-alto: #dbdbdb;
+
 $color-black: #000;
 
 $color-black-haze: #f6f7f7;

--- a/src/components/LabeledTags.vue
+++ b/src/components/LabeledTags.vue
@@ -43,15 +43,11 @@ export default defineComponent({
 
 <style scoped
        lang="scss">
-
-@import 'node_modules/bulma/sass/utilities/initial-variables.sass';
-@import 'node_modules/bulma/sass/utilities/functions.sass';
-@import 'node_modules/bulma/sass/utilities/derived-variables.sass';
-@import 'node_modules/bulma/sass/helpers/color.sass';
+@import 'src/assets/styles/colors';
 
 .labeled-tag {
-  @extend .has-background-grey-lighter;
-  border: 1px solid #fff;
+  background-color: $color-alto;
+  border: 1px solid $color-white;
   border-radius: 10px;
   margin-right: 0.25rem;
   max-width: 90%;

--- a/src/components/RbzChart.vue
+++ b/src/components/RbzChart.vue
@@ -241,7 +241,7 @@ export default defineComponent({
     // Programmatically change the width of the chart based on component width on window resize
     setChartSize() {
       const wrapperElement = this.$refs.chartWrapper
-      if (wrapperElement) {
+      if (wrapperElement && this.chart) {
         this.chart.setSize({
           width: wrapperElement.clientWidth,
           height: this.chartHeight,

--- a/src/components/RbzDatePicker.vue
+++ b/src/components/RbzDatePicker.vue
@@ -4,12 +4,13 @@
               enable-seconds
               auto-apply
               utc="preserve"
-              format="yyyy-MM-dd HH:mm"
+              format="dd-MM-yyyy HH:mm"
               input-class-name="input is-small is-size-7 width-260px date-picker-input"
               :close-on-auto-apply="false"
               :month-change-on-scroll="false"
               :clearable="false"
               :time-picker-component="timePicker"
+              disable-time-range-validation
               :preset-ranges="presetRanges"
               @open="loadPresetRanges()">
   </Datepicker>
@@ -50,6 +51,8 @@ export default defineComponent({
     loadPresetRanges() {
       const now = new Date()
       const utcNow = new Date((now.getTimezoneOffset() * MS_PER_MINUTE) + now.getTime())
+      utcNow.setSeconds(0)
+      utcNow.setMilliseconds(0)
       this.presetRanges = [
         {
           label: 'Last 30 Minutes',
@@ -84,6 +87,8 @@ export default defineComponent({
 
     getDefaultDate() {
       const now = new Date()
+      now.setSeconds(0)
+      now.setMilliseconds(0)
       return [new Date(now.getTime() - (HOUR / 2)), now]
     },
 

--- a/src/reblaze-dashboards/DefaultDashboard.vue
+++ b/src/reblaze-dashboards/DefaultDashboard.vue
@@ -232,7 +232,7 @@ type topTableData = {
   rowIdentification?: string
   passed?: number
   blocked?: number
-  report?: number
+  reported?: number
 }
 
 export default defineComponent({
@@ -268,8 +268,8 @@ export default defineComponent({
         classes: 'width-80px',
       },
       {
-        title: 'Report',
-        fieldNames: ['report'],
+        title: 'Reported',
+        fieldNames: ['reported'],
         isSortable: true,
         isNumber: true,
         classes: 'width-80px',
@@ -303,8 +303,8 @@ export default defineComponent({
           strokeColor: '#ff355e', // $color-radical-red
         },
         {
-          title: 'Report',
-          fieldName: 'report',
+          title: 'Reported',
+          fieldName: 'reported',
           show: true,
           drawStyle: 'spline',
           fillColor: `rgba(${Utils.hexToRgbArray('#ffdb58').join(', ')}, 0.1)`,
@@ -465,7 +465,7 @@ export default defineComponent({
         const hits = dataItem.counters.hits
         const passed = dataItem.counters.passed
         const blocked = dataItem.counters.active
-        const report = dataItem.counters.report
+        const reported = dataItem.counters.reported
         const humans = dataItem.counters.human
         const bots = dataItem.counters.bot
         returnArray.push({
@@ -473,7 +473,7 @@ export default defineComponent({
           hits: hits > 0 ? hits : 0,
           passed: passed > 0 ? passed : 0,
           blocked: blocked > 0 ? blocked : 0,
-          report: report > 0 ? report : 0,
+          reported: reported > 0 ? reported : 0,
           humans: humans > 0 ? humans : 0,
           bots: bots > 0 ? bots : 0,
         })
@@ -549,12 +549,12 @@ export default defineComponent({
       for (const appId of Object.keys(groupedObject)) {
         const passed = _.sumBy(groupedObject[appId], (item) => item.counters.passed)
         const blocked = _.sumBy(groupedObject[appId], (item) => item.counters.active)
-        const report = _.sumBy(groupedObject[appId], (item) => item.counters.report)
+        const reported = _.sumBy(groupedObject[appId], (item) => item.counters.reported)
         returnArray.push({
           rowIdentification: appId,
           passed: passed > 0 ? passed : 0,
           blocked: blocked > 0 ? blocked : 0,
-          report: report > 0 ? report : 0,
+          reported: reported > 0 ? reported : 0,
         })
       }
       return returnArray
@@ -605,7 +605,7 @@ export default defineComponent({
       this.statusesClassDetails = !this.statusesClassDetails
     },
 
-    buildTopDataFromCounters(blocksFieldName: string, passedFieldName: string, reportFieldName: string) {
+    buildTopDataFromCounters(blocksFieldName: string, passedFieldName: string, reportedFieldName: string) {
       const returnArray = []
       const groupedObject: { [key: string]: topTableData } = {}
       this.data.forEach((item) => {
@@ -629,14 +629,14 @@ export default defineComponent({
             groupedObject[escapedKey].passed += passedItem.value || 0
           }
         }
-        if (item.counters[reportFieldName]) {
-          for (const reportedItem of item.counters[reportFieldName]) {
-            const escapedKey = _.escape(reportedItem.key)
+        if (item.counters[reportedFieldName]) {
+          for (const reportededItem of item.counters[reportedFieldName]) {
+            const escapedKey = _.escape(reportededItem.key)
             if (!groupedObject[escapedKey]) {
               groupedObject[escapedKey] = {}
             }
-            groupedObject[escapedKey].report = groupedObject[escapedKey].report || 0
-            groupedObject[escapedKey].report += reportedItem.value || 0
+            groupedObject[escapedKey].reported = groupedObject[escapedKey].reported || 0
+            groupedObject[escapedKey].reported += reportededItem.value || 0
           }
         }
       })
@@ -645,7 +645,7 @@ export default defineComponent({
           rowIdentification: key,
           passed: groupedObject[key].passed > 0 ? groupedObject[key].passed : 0,
           blocked: groupedObject[key].blocked > 0 ? groupedObject[key].blocked : 0,
-          report: groupedObject[key].report > 0 ? groupedObject[key].report : 0,
+          reported: groupedObject[key].reported > 0 ? groupedObject[key].reported : 0,
         })
       }
       return returnArray

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -49,12 +49,14 @@ const routes: Array<RouteRecordRaw> = [
     path: '/',
     name: 'MainComponent',
     component: MainComponent,
-    redirect: ':branch/dashboard',
+    redirect: 'prod/dashboard',
     children: [
       {
         path: ':branch',
         name: 'MainComponent/Branch',
-        redirect: ':branch/dashboard',
+        redirect: (route) => {
+          return `/${route.params.branch}/dashboard`
+        },
         children: [
           {
             path: 'server-groups',

--- a/src/stores/BranchesStore.ts
+++ b/src/stores/BranchesStore.ts
@@ -76,7 +76,7 @@ export const useBranchesStore = defineStore('branches', () => {
 
   async function setSelectedBranch(id ?: Branch['id']) {
     const branches = await list.value
-    let newId = branches[0].id
+    let newId = 'prod'
     if (id) {
       const branch = branches.find((branch: Branch) => {
         return branch.id === id


### PR DESCRIPTION
Fix bug in RbzDatePicker where seconds were not reset
Fix bug in RbzDatePicker where selecting invalid time would invalidate the entire time picking
Change default branch to `prod` rather than first branch in the alphabet
Change `latency` box to `processing time`, now includes processing time, latency, and upstream response time in Events Log Details
Change upstream details to be a single line rather than collapsed card in Events Log details
Change order of boxes in Events Log details
Add group by tags, will now group by tag type. Grouping by clicking `geo-country:united-states` will group by different values of `geo-country`
Change grouped-by label and ungroup button design in Events Log
Change field name from `report` to `reported` in Dashboard aggregated data to reflect newest data structure
Change chart in Events Log to display 1/10th of seconds if all the requests displayed are in the same second
Change grouping of tags in Events Log details from legitimate/malicious/neutral to policies/rtc/geo/informative(other)
Add background color to selected and hovered requested in Events Log page

Signed-off-by: Aviv-Galmidi <AvivGalmidi@gmail.com>