### PR TITLE
V5.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "dependencies": {
         "@mdi/font": "^5.9.55",
         "@mdi/js": "^5.9.55",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "dependencies": {
         "@mdi/font": "^5.9.55",
         "@mdi/js": "^5.9.55",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "dependencies": {
         "@mdi/font": "^5.9.55",
         "@mdi/js": "^5.9.55",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dependencies": {
         "@mdi/font": "^5.9.55",
         "@mdi/js": "^5.9.55",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dependencies": {
         "@mdi/font": "^5.9.55",
         "@mdi/js": "^5.9.55",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/assets/RequestsUtils.ts
+++ b/src/assets/RequestsUtils.ts
@@ -48,6 +48,10 @@ const processRequest = (requestParams: IRequestParams) => {
     }
   }
   request = request.then((response: AxiosResponse) => {
+    // Follow redirect
+    if (response?.request?.location) {
+      window.location.href = response.request.location
+    }
     // Toast message
     if (requestParams.successMessage) {
       Utils.toast(requestParams.successMessage, 'is-success', requestParams.undoFunction)

--- a/src/assets/__tests__/RequestsUtils.spec.ts
+++ b/src/assets/__tests__/RequestsUtils.spec.ts
@@ -212,6 +212,40 @@ describe('RequestsUtils.ts', () => {
           requestFunc({methodName: 'DELETE', url, successMessage, failureMessage, onFail})
         })
       })
+
+      describe('redirect response', () => {
+        let originalLocation
+        beforeEach(() => {
+          const location = JSON.stringify(window.location)
+          originalLocation = window.location
+          delete window.location
+
+          window.location = JSON.parse(location)
+          window.location.href = 'http://localhost/test'
+        })
+        afterEach(() => {
+          window.location = originalLocation
+        })
+
+        test('should not attempt to redirect if no redirect info received from the server', async () => {
+          getSpy = jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve())
+          await requestFunc({methodName: 'GET', url})
+          expect(window.location.href).toEqual('http://localhost/test')
+          jest.clearAllMocks()
+        })
+
+        test('should attempt to redirect if redirect info received from the server', async () => {
+          const wantedURL = 'http://127.0.0.1/testOtherPath'
+          getSpy = jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve({
+            request: {
+              location: wantedURL,
+            },
+          }))
+          await requestFunc({methodName: 'GET', url})
+          expect(window.location.href).toEqual(wantedURL)
+          jest.clearAllMocks()
+        })
+      })
     })
   }
 

--- a/src/assets/styles/colors.scss
+++ b/src/assets/styles/colors.scss
@@ -43,5 +43,3 @@ $color-science-blue: #06c;
 $color-white: #fff;
 
 $color-wild-sand: #f4f4f4;
-
-$color-wild-sand: #f4f4f4;

--- a/src/assets/styles/colors.scss
+++ b/src/assets/styles/colors.scss
@@ -22,6 +22,8 @@ $color-curious-blue: #2596d1;
 
 $color-emerald: #50c878;
 
+$color-mercury: #e5e5e5;
+
 $color-mustard: #ffdb58;
 
 $color-nobel: #b7b1b1;
@@ -39,5 +41,7 @@ $color-salmon: #ff8c69;
 $color-science-blue: #06c;
 
 $color-white: #fff;
+
+$color-wild-sand: #f4f4f4;
 
 $color-wild-sand: #f4f4f4;

--- a/src/components/DnsPage.vue
+++ b/src/components/DnsPage.vue
@@ -67,7 +67,7 @@ export default defineComponent({
           },
           isSortable: true,
           isSearchable: true,
-          cellContentClasses: 'multi-line white-space-pre word-break-all',
+          cellContentClasses: 'vertical-scroll multi-line white-space-pre word-break-all',
         },
       ] as ColumnOptions[],
       dnsRecords: [] as undefined as DnsRecord[],
@@ -110,8 +110,7 @@ export default defineComponent({
 
 :deep(.multi-line) {
   height: fit-content;
-  max-height: fit-content;
-  min-height: 150px;
+  max-height: 10rem;
 }
 
 </style>

--- a/src/components/EventsLogRow.vue
+++ b/src/components/EventsLogRow.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="box event-row-box mb-0">
+  <div class="box event-row-box mb-0"
+       :class="{'event-row-box-open': eventFullDetails}">
     <div class="event-row-summary is-fullwidth mb-0 is-clickable"
-         :class="{'event-row-summary-open': eventFullDetails}"
          @click="toggleShowFullDetails()">
       <div class="columns event-row-summary-columns mb-0">
         <span class="column width-10px">
@@ -983,14 +983,22 @@ $event-row-box-horizontal-padding: 1rem;
 
 .event-row-box {
   background-color: $color-black-haze;
+  border: 1px solid $color-wild-sand;
+  border-radius: 0;
+  border-top: 0;
   padding: 0 $event-row-box-horizontal-padding;
+}
+
+.event-row-box-open {
+  background-color: $color-black-haze;
+  border: 1px solid $color-nobel;
+  border-top: 0;
 }
 
 .event-row-summary {
   background-color: $color-white;
-  border: 1px solid $color-white;
-  border-bottom: 1px solid $color-nobel;
-  border-radius: 6px;
+  border-radius: 0;
+  border-top: 1px solid $color-white;
   height: 4rem;
   line-height: 2rem;
   margin-left: - $event-row-box-horizontal-padding;
@@ -1003,13 +1011,19 @@ $event-row-box-horizontal-padding: 1rem;
   z-index: 10;
 }
 
-.event-row-summary:hover {
+.event-row-box-open .event-row-summary {
   background-color: $color-black-haze;
+  border-bottom: 1px solid $color-mercury;
+  border-top: 1px solid $color-nobel;
 }
 
-.event-row-summary-open {
+.event-row-summary:hover {
   background-color: $color-black-haze;
-  border: 1px solid $color-nobel;
+  border-top: 1px solid $color-black-haze;
+}
+
+.event-row-box-open .event-row-summary:hover {
+  border-top: 1px solid $color-nobel;
 }
 
 .event-row-summary-columns {

--- a/src/components/QuarantinedList.vue
+++ b/src/components/QuarantinedList.vue
@@ -322,10 +322,4 @@ export default defineComponent({
   box-shadow: none;
   font-weight: 200;
 }
-
-:deep(.multi-line) {
-  height: fit-content;
-  max-height: fit-content;
-  min-height: 50px;
-}
 </style>

--- a/src/components/RbzTable.vue
+++ b/src/components/RbzTable.vue
@@ -14,13 +14,6 @@
              v-if="showMenuColumn"/>
       </colgroup>
       <thead>
-      <tr class="header-row"
-          v-if="tableTitle">
-        <th :colspan="totalColumns"
-            class="has-text-centered table-title">
-          {{ tableTitle }}
-        </th>
-      </tr>
       <tr class="header-row">
         <th class="is-size-7 width-45px"
             v-if="showCheckboxColumn">
@@ -36,23 +29,20 @@
         <th v-for="(col, index) in columns"
             :key="index"
             class="column-header is-size-7 column-title"
-            :class="`
-              ${col.classes ? col.classes : ''}
-              ${col.isSortable ? 'is-clickable' : ''}
-            `"
+            :class="`${col.classes || ''}${col.isSortable ? 'is-clickable' : ''}`"
             @click="sortColumn(col)">
-          <div v-if="col.isSortable">
-            <div class="arrow-wrapper">
-              <span class="arrow arrow-asc"
-                    :class="{'is-active': sortColumnTitle === col.title && sortDirection === 'asc'}"/>
-            </div>
-            <div class="arrow-wrapper">
-              <span class="arrow arrow-desc"
-                    :class="{'is-active': sortColumnTitle === col.title && sortDirection === 'desc'}"/>
-            </div>
-          </div>
-          <span>
-            {{ col.title }}
+          <span class="is-flex is-justify-content-space-between">
+            <span>
+              {{ col.title }}
+            </span>
+            <span v-show="col.isSortable">
+              <div v-show="sortColumnTitle === col.title && sortDirection === 'asc'">
+                <i class="fas fa-sort-up"></i>
+              </div>
+              <div v-show="sortColumnTitle === col.title && sortDirection === 'desc'">
+                <i class="fas fa-sort-down"></i>
+              </div>
+            </span>
           </span>
         </th>
         <th class="column-header is-relative has-text-centered"
@@ -151,10 +141,7 @@
           <td v-for="(col, index) in columns"
               :key="index"
               class="data-cell is-size-7"
-              :class="`
-                ${col.classes ? col.classes : ''}
-                ${verticalAlignTop ? 'vertical-align-top' : 'vertical-align-middle'}
-              `">
+              :class="`${col.classes || ''}${verticalAlignTop ? 'vertical-align-top' : 'vertical-align-middle'}`">
             <div class="data-cell-content"
                  :class="col.cellContentClasses">
               <span v-if="col.displayFunction"
@@ -275,7 +262,6 @@ export default defineComponent({
       },
     },
     secondRowButtonIcon: String,
-    tableTitle: String,
     rowsPerPage: {
       type: Number,
       default: 10,
@@ -536,36 +522,6 @@ export default defineComponent({
 .rbz-table {
   border-collapse: separate;
   table-layout: fixed;
-}
-
-.rbz-table .arrow-wrapper {
-  float: right;
-  height: 0;
-}
-
-.rbz-table .arrow {
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  display: inline-block;
-  height: 0;
-  opacity: 0.3;
-  width: 0;
-}
-
-.rbz-table .arrow.is-active {
-  opacity: 1;
-}
-
-.rbz-table .arrow-asc {
-  border-bottom: 6px solid #000;
-  border-top: 0;
-  vertical-align: top;
-}
-
-.rbz-table .arrow-desc {
-  border-bottom: 0;
-  border-top: 6px solid #000;
-  vertical-align: bottom;
 }
 
 .rbz-table.table.is-hoverable tbody tr:hover {

--- a/src/components/RbzTable.vue
+++ b/src/components/RbzTable.vue
@@ -29,7 +29,7 @@
         <th v-for="(col, index) in columns"
             :key="index"
             class="column-header is-size-7 column-title"
-            :class="`${col.classes || ''}${col.isSortable ? 'is-clickable' : ''}`"
+            :class="`${col.classes || ''} ${col.isSortable ? 'is-clickable' : ''}`"
             @click="sortColumn(col)">
           <span class="is-flex is-justify-content-space-between">
             <span>
@@ -141,7 +141,7 @@
           <td v-for="(col, index) in columns"
               :key="index"
               class="data-cell is-size-7"
-              :class="`${col.classes || ''}${verticalAlignTop ? 'vertical-align-top' : 'vertical-align-middle'}`">
+              :class="`${col.classes || ''} ${verticalAlignTop ? 'vertical-align-top' : 'vertical-align-middle'}`">
             <div class="data-cell-content"
                  :class="col.cellContentClasses">
               <span v-if="col.displayFunction"
@@ -204,13 +204,13 @@
         class="pagination-row">
       <td :colspan="totalColumns">
         <div class="pagination is-small">
-          <button class="pagination-button mx-1 my-2 pagination-button-previous"
+          <button class="pagination-button mx-1 my-2 pagination-button-previous is-size-7"
                   @click="prevPage"
                   :disabled="currentPage === 1"
                   :class="{'pagination-button-active' : currentPage !== 1 }">
             Previous Page
           </button>
-          <button class="pagination-button mx-1 my-2 pagination-button-next"
+          <button class="pagination-button mx-1 my-2 pagination-button-next is-size-7"
                   @click="nextPage"
                   :disabled="currentPage === totalPages"
                   :class="{'pagination-button-active' : currentPage !== totalPages }">
@@ -529,7 +529,7 @@ export default defineComponent({
 }
 
 .rbz-table th {
-  background-color: #eef6fc;
+  background-color: $color-wild-sand;
   padding: 0.25em 0.5em;
   vertical-align: baseline;
 }

--- a/src/components/__tests__/RbzTable.spec.ts
+++ b/src/components/__tests__/RbzTable.spec.ts
@@ -101,31 +101,31 @@ describe('RbzTable.vue', () => {
 
   describe('sorting', () => {
     test('should have the correct first asc arrow active by default', () => {
-      const ascArrowElement = wrapper.find('.arrow-asc')
-      expect(ascArrowElement.element.classList).toContain('is-active')
+      const arrowElement = wrapper.find('.fa-sort-up')
+      expect(arrowElement.isVisible()).toBeTruthy()
     })
 
     test('should have asc arrow active on click on non sorted column', async () => {
       const header = wrapper.findAll('.column-title').at(1)
       await header.trigger('click')
-      const arrowElement = header.find('.arrow-asc')
-      expect(arrowElement.element.classList).toContain('is-active')
+      const arrowElement = header.find('.fa-sort-up')
+      expect(arrowElement.isVisible()).toBeTruthy()
     })
 
     test('should have desc arrow active on click on asc sorted column', async () => {
       const header = wrapper.findAll('.column-title').at(1)
       await header.trigger('click')
       await header.trigger('click')
-      const arrowElement = header.find('.arrow-desc')
-      expect(arrowElement.element.classList).toContain('is-active')
+      const arrowElement = header.find('.fa-sort-down')
+      expect(arrowElement.isVisible()).toBeTruthy()
     })
 
     test('should have asc arrow active on click on desc sorted column', async () => {
       const nameCell = wrapper.findAll('.column-title').at(0)
       await nameCell.trigger('click')
       await nameCell.trigger('click')
-      const arrowElement = nameCell.find('.arrow-asc')
-      expect(arrowElement.element.classList).toContain('is-active')
+      const arrowElement = nameCell.find('.fa-sort-up')
+      expect(arrowElement.isVisible()).toBeTruthy()
     })
 
     test('should be able to sort null values', async () => {
@@ -229,8 +229,8 @@ describe('RbzTable.vue', () => {
       await descriptionCell.trigger('click')
       const nameCell = wrapper.findAll('.column-title').at(0)
       await nameCell.trigger('click')
-      const ascArrowElement = wrapper.findAll('.arrow-asc').at(0)
-      expect(ascArrowElement.element.classList).toContain('is-active')
+      const arrowElement = wrapper.findAll('.fa-sort-up').at(0)
+      expect(arrowElement.isVisible()).toBeTruthy()
     })
 
     test('should have asc arrow in new sort column when previous sort column was dsec order', async () => {
@@ -238,8 +238,8 @@ describe('RbzTable.vue', () => {
       await nameCell.trigger('click')
       const descriptionCell = wrapper.findAll('.column-title').at(1)
       await descriptionCell.trigger('click')
-      const ascArrowElement = wrapper.findAll('.arrow-asc').at(1)
-      expect(ascArrowElement.element.classList).toContain('is-active')
+      const arrowElement = wrapper.findAll('.fa-sort-up').at(1)
+      expect(arrowElement.isVisible()).toBeTruthy()
     })
 
     test('should not have is-clickable class in column header when the column is non sortable', () => {
@@ -306,8 +306,8 @@ describe('RbzTable.vue', () => {
       ]
       await wrapper.setProps({columns: columns})
       const firstHeader = wrapper.findAll('.column-title').at(0)
-      const ascArrowElement = firstHeader.find('.arrow-asc')
-      expect(ascArrowElement.element.classList).toContain('is-active')
+      const arrowElement = firstHeader.find('.fa-sort-up')
+      expect(arrowElement.isVisible()).toBeTruthy()
     })
   })
 

--- a/src/doc-editors/ServerGroupsEditor.vue
+++ b/src/doc-editors/ServerGroupsEditor.vue
@@ -750,6 +750,9 @@ export default defineComponent({
       if (!data) {
         data = this.selectedServerGroup
       }
+      data.server_names = _.filter(data.server_names, (serverName: string) => {
+        return serverName?.length > 0
+      })
       const url = `configs/${this.selectedBranch}/d/sites/e/${data.id}/`
       const serverGroupText = this.titles['sites-singular']
       if (!successMessage) {

--- a/src/doc-editors/popups/AttachCertificate.vue
+++ b/src/doc-editors/popups/AttachCertificate.vue
@@ -93,13 +93,13 @@ export default defineComponent({
     }
   },
   computed: {
-    filteredCertificates() {
+    filteredCertificates(): Certificate[] {
       return _.filter(this.certificates, (certificate: Certificate) => {
         return certificate.id.toLowerCase().includes(this.certsToAttach.toLowerCase())
       })
     },
 
-    filteredCertificatesToAttach() {
+    filteredCertificatesToAttach(): Certificate[] {
       if (this.selectedBalancer) {
         let currentLoadBalancerCertificates = this.selectedBalancer.certificates.slice()
         currentLoadBalancerCertificates.push(this.selectedBalancer.default_certificate)

--- a/src/doc-editors/popups/AttachCertificate.vue
+++ b/src/doc-editors/popups/AttachCertificate.vue
@@ -4,59 +4,59 @@
       <div class="modal-card is-size-7">
         <header class="modal-card-head">
           <h5 class="modal-card-title is-size-6 mb-0"
-            :title="selectedBalancer.name">
+              :title="selectedBalancer.name">
             Select certificate to attach to {{ selectedBalancer.name }}
           </h5>
           <button class="delete"
-            aria-label="close"
-            @click="closeAttachCertPopup"/>
+                  aria-label="close"
+                  @click="closeAttachCertPopup"/>
         </header>
         <section class="modal-card-body">
           <div id="attach-modal-content">
             <div class="mb-1 certificate-search">
               <input v-model="certsToAttach"
-                type="text"
-                class="input is-small search-input"
-                placeholder="Filter by name">
+                     type="text"
+                     class="input is-small search-input"
+                     placeholder="Filter by name">
             </div>
             <div class="table-container table-content">
               <table class="table is-fullwidth table-balancers is-size-7 is-striped">
                 <thead>
-                  <tr>
-                    <th class="is-size-7 is-60">
-                      Name
-                    </th>
-                    <th class="is-size-7 is-20">
-                      Expiration Date
-                    </th>
-                    <th class="is-size-7 is-20" />
-                  </tr>
+                <tr>
+                  <th class="is-size-7 is-60">
+                    Name
+                  </th>
+                  <th class="is-size-7 is-20">
+                    Expiration Date
+                  </th>
+                  <th class="is-size-7 is-20"/>
+                </tr>
                 </thead>
                 <tbody v-if="filteredCertificatesToAttach.length">
-                  <tr v-for="(certificate, idx) in filteredCertificatesToAttach"
+                <tr v-for="(certificate, idx) in filteredCertificatesToAttach"
                     :key="idx">
-                    <td class="is-size-7 is-vcentered is-60">
-                      {{ certificate.id }}
-                    </td>
-                    <td class="is-size-7 is-vcentered is-20">
-                      {{ certificate.exp_date }}
-                    </td>
-                    <td class="is-size-7 is-vcentered is-20 has-text-right">
-                      <button class="button is-small is-outlined"
-                        @click="attachCertificateToLoadBalancer(selectedBalancer, certificate.id, false, '', certificate)"
-                        :class="{'is-loading' : certificate.loading}">
-                        Attach
-                      </button>
-                    </td>
-                  </tr>
+                  <td class="is-size-7 is-vcentered is-60">
+                    {{ certificate.id }}
+                  </td>
+                  <td class="is-size-7 is-vcentered is-20">
+                    {{ certificate.exp_date }}
+                  </td>
+                  <td class="is-size-7 is-vcentered is-20 has-text-right">
+                    <button class="button is-small is-outlined"
+                            @click="emitAttachCertificateToLoadBalancer(certificate)"
+                            :class="{'is-loading' : certificate.loading}">
+                      Attach
+                    </button>
+                  </td>
+                </tr>
                 </tbody>
                 <tbody v-else>
-                  <tr>
-                    <td colspan="3"
+                <tr>
+                  <td colspan="3"
                       class="is-size-7 is-vcentered has-text-centered no-certificate">
-                      No certificates found
-                    </td>
-                  </tr>
+                    No certificates found
+                  </td>
+                </tr>
                 </tbody>
               </table>
             </div>
@@ -65,7 +65,7 @@
         <footer class="modal-card-foot">
           <div class="buttons is-right is-fullwidth">
             <button class="button is-small"
-              @click="closeAttachCertPopup">
+                    @click="closeAttachCertPopup">
               Close
             </button>
           </div>
@@ -84,10 +84,9 @@ export default defineComponent({
     clickedRow: String,
     certificates: Array as PropType<Certificate[]>,
     selectedBalancer: Object,
-    attachCertificateToLoadBalancer: Function,
     isAttachLoading: Boolean,
   },
-  emits: ['attach-shown-changed'],
+  emits: ['attach-shown-changed', 'attach-certificate-to-load-balancer'],
   data() {
     return {
       certsToAttach: ref(''),
@@ -95,7 +94,7 @@ export default defineComponent({
   },
   computed: {
     filteredCertificates() {
-      return _.filter(this.certificates, (certificate:Certificate) => {
+      return _.filter(this.certificates, (certificate: Certificate) => {
         return certificate.id.toLowerCase().includes(this.certsToAttach.toLowerCase())
       })
     },
@@ -107,18 +106,17 @@ export default defineComponent({
         currentLoadBalancerCertificates = currentLoadBalancerCertificates.join()
         return _.filter(this.filteredCertificates, (certificate: Certificate) => {
           if (this.selectedBalancer.provider === 'gcp') {
-            const gcpLinks = _.filter(certificate.links, (link:Link) => {
+            const gcpLinks = _.filter(certificate.links, (link: Link) => {
               return link.provider === 'gcp'
             })
-            return !gcpLinks.length || _.some(gcpLinks, (gcpLink:Link) => {
+            return !gcpLinks.length || _.some(gcpLinks, (gcpLink: Link) => {
               return !currentLoadBalancerCertificates.includes(gcpLink.link)
             })
           } else if (this.selectedBalancer.provider === 'aws') {
-            const awsLinks = _.filter(certificate?.links, (link:Link) => {
-              console.log('link.provider', link.provider)
+            const awsLinks = _.filter(certificate?.links, (link: Link) => {
               return link.provider === 'aws'
             })
-            return !awsLinks.length || _.some(awsLinks, (awsLink:Link) => {
+            return !awsLinks.length || _.some(awsLinks, (awsLink: Link) => {
               return !currentLoadBalancerCertificates.includes(awsLink.link)
             })
           }
@@ -133,20 +131,27 @@ export default defineComponent({
       this.$emit('attach-shown-changed', false)
       this.certsToAttach = ''
     },
+
+    emitAttachCertificateToLoadBalancer(certificate: Certificate) {
+      this.$emit('attach-certificate-to-load-balancer', {
+        selectedBalancer: this.selectedBalancer,
+        certificate,
+      })
+    },
   },
 })
 </script>
 <style lang="scss">
-  .certificate-search {
-    position: relative;
-    top: -5px;
-  }
+.certificate-search {
+  position: relative;
+  top: -5px;
+}
 
-  .search-input {
-    width: 300px;
-  }
+.search-input {
+  width: 300px;
+}
 
-  .no-certificate {
-    width: 100%;
-  }
+.no-certificate {
+  width: 100%;
+}
 </style>

--- a/src/doc-editors/popups/DeleteCertificate.vue
+++ b/src/doc-editors/popups/DeleteCertificate.vue
@@ -7,8 +7,8 @@
             Remove certificate
           </h5>
           <button class="delete"
-            aria-label="close"
-            @click="$emit('delete-shown-changed', false)"/>
+                  aria-label="close"
+                  @click="$emit('delete-shown-changed', false)"/>
         </header>
         <section class="modal-card-body is-size-6 has-text-centered">
           <p class="is-small is-size-6">
@@ -16,18 +16,18 @@
             <strong>{{ clickedRow }}</strong>?
           </p>
           <p v-if="attachedApps"
-            class="is-small is-size-6 mt-2"
-            v-html="attachedApps"/>
+             class="is-small is-size-6 mt-2"
+             v-html="attachedApps"/>
         </section>
         <footer class="modal-card-foot">
           <div class="buttons is-right is-fullwidth">
             <button class="button is-small"
-              @click="$emit('delete-shown-changed', false)">
+                    @click="$emit('delete-shown-changed', false)">
               Cancel
             </button>
             <button class="button is-small is-light is-outlined is-danger"
-              :class="{'is-loading': isLoading}"
-              @click="deleteCertificate()">
+                    :class="{'is-loading': isLoading}"
+                    @click="deleteCertificate()">
               Delete
             </button>
           </div>
@@ -40,6 +40,7 @@
 import DatasetsUtils from '@/assets/DatasetsUtils'
 import RequestsUtils from '@/assets/RequestsUtils'
 import {defineComponent} from 'vue'
+
 export default defineComponent({
   props: {
     deleteShown: Boolean,
@@ -75,7 +76,8 @@ export default defineComponent({
   },
 })
 </script>
-<style scoped lang="scss">
+<style scoped
+       lang="scss">
 .modal-location {
   margin-bottom: 8px;
   margin-top: -5px;

--- a/src/doc-editors/popups/EditCertificate.vue
+++ b/src/doc-editors/popups/EditCertificate.vue
@@ -4,75 +4,75 @@
       <div class="modal-card is-size-7">
         <header class="modal-card-head">
           <h5 class="modal-card-title is-size-6 mb-0"
-            :title="clickedRow">
+              :title="clickedRow">
             Edit certificate - {{ clickedRow }}
           </h5>
           <button class="delete"
-            aria-label="close"
-            @click="resetEditModal"/>
+                  aria-label="close"
+                  @click="resetEditModal"/>
         </header>
         <section class="modal-card-body">
           <div v-if="getConnectedSitesForEditCert"
-            class="control content is-small mb-2">
+               class="control content is-small mb-2">
             Connected sites:
             <input :value="getConnectedSitesForEditCert"
-              class="input is-small"
-              :title="getConnectedSitesForEditCert"
-              type="text"
-              disabled>
+                   class="input is-small"
+                   :title="getConnectedSitesForEditCert"
+                   type="text"
+                   disabled>
           </div>
           <div class="control content is-small mb-2">
             Certificate subject:
             <input :value="localCert.subject"
-              class="input is-small"
-              :title="localCert.subject"
-              type="text"
-              disabled>
+                   class="input is-small"
+                   :title="localCert.subject"
+                   type="text"
+                   disabled>
           </div>
           <div class="control content is-small mb-2">
             Certificate issuer:
             <input :value="localCert.issuer"
-              class="input is-small"
-              :title="localCert.issuer"
-              type="text"
-              disabled>
+                   class="input is-small"
+                   :title="localCert.issuer"
+                   type="text"
+                   disabled>
           </div>
           <div class="control content is-small mb-2">
             SAN:
             <input :value="localCert.san.toString()"
-              class="input is-small"
-              :title="localCert.san.toString()"
-              type="text"
-              disabled>
+                   class="input is-small"
+                   :title="localCert.san.toString()"
+                   type="text"
+                   disabled>
           </div>
           <div class="control content is-small mb-2">
             Certificate body:
             <textarea v-html="localCert.cert_body"
-              class="textarea is-small cert-body"
-              disabled/>
+                      class="textarea is-small cert-body"
+                      disabled/>
           </div>
           <div v-if="certCanReplaceByLE"
-            class="control content is-small mb-0 mt-4">
+               class="control content is-small mb-0 mt-4">
             <label class="checkbox is-align-items-center is-inline-flex">
               <input type="checkbox"
-                v-model="localCert.le_auto_replace"
-                @change="updateLetsEncrypt = !updateLetsEncrypt"
-                class="mr-1">
+                     v-model="localCert.le_auto_replace"
+                     @change="updateLetsEncrypt = !updateLetsEncrypt"
+                     class="mr-1">
               Auto Replacement by&nbsp;
               <a href="https://letsencrypt.org"
-                target="_blank">
-              Let's Encrypt
+                 target="_blank">
+                Let's Encrypt
               </a>
             </label>
           </div>
           <div class="tabs is-small">
             <ul class="ml-0">
               <li @click="certAction='attach_to_application'"
-                :class="{'is-active': isAttachSelectedOnEdit}">
+                  :class="{'is-active': isAttachSelectedOnEdit}">
                 <a>Attach to application</a>
               </li>
               <li @click="certAction='replace_certificate'"
-                :class="{'is-active': isReplaceSelectedOnEdit}">
+                  :class="{'is-active': isReplaceSelectedOnEdit}">
                 <a>Replace existing certificates</a>
               </li>
             </ul>
@@ -84,14 +84,14 @@
                   {{ selectedAppsLabel }}
                 </div>
                 <select v-model="selectedApps"
-                  class="width-400px"
-                  multiple
-                  title="Select links"
-                  :loading="isLoading"
-                  :option-height="10">
+                        class="width-400px"
+                        multiple
+                        title="Select links"
+                        :loading="isLoading"
+                        :option-height="10">
                   <option v-for="site in sites"
-                    :key="site.id"
-                    :value="site">
+                          :key="site.id"
+                          :value="site">
                     {{ site.name }}
                   </option>
                 </select>
@@ -102,17 +102,20 @@
                 <div class="control">
                   <div class="select is-small">
                     <select v-model="selectedCertId"
-                      class="width-400px"
-                      id="selectCert">
+                            class="width-400px"
+                            id="selectCert">
                       <option value=""
-                        disabled
-                        key="no_value">
-                        {{ assignedCertsNamesExceptCurrent.length ? 'Select certificate' : '-- No certificates to replace --' }}
+                              disabled
+                              key="no_value">
+                        {{
+                          assignedCertsExceptCurrent.length ?
+                            'Select certificate' : '-- No certificates to replace --'
+                        }}
                       </option>
-                      <option v-for="(certId, index) in assignedCertsNamesExceptCurrent"
-                        :value="certId"
-                        :key="index">
-                        {{ certId }}
+                      <option v-for="(cert, index) in assignedCertsExceptCurrent"
+                              :value="cert.id"
+                              :key="index">
+                        {{ cert.name }}
                       </option>
                     </select>
                   </div>
@@ -124,21 +127,21 @@
         <footer class="modal-card-foot columns">
           <div class="column is-9">
             <button class="button is-light has-text-info is-small"
-              type="submit"
-              @click="downloadPFX">
+                    type="submit"
+                    @click="downloadPFX">
               Download PFX
             </button>
           </div>
           <div class="column is-3 has-text-right">
             <button class="button is-small"
-              @click="resetEditModal"
-              v-if="!isLoading">
+                    @click="resetEditModal"
+                    v-if="!isLoading">
               Cancel
             </button>
             <button @click="saveChanges"
-              :disabled="isSaveEditDisabled"
-              class="button is-small"
-              :class="{ 'is-loading': isLoading }">
+                    :disabled="isSaveEditDisabled"
+                    class="button is-small"
+                    :class="{ 'is-loading': isLoading }">
               Save
             </button>
           </div>
@@ -150,9 +153,10 @@
 <script lang="ts">
 import RequestsUtils from '@/assets/RequestsUtils'
 import Utils from '@/assets/Utils'
-import {Balancer, Certificate, Site} from '@/types'
+import {Balancer, Certificate, Link, Site} from '@/types'
 import _ from 'lodash'
 import {defineComponent, PropType} from 'vue'
+
 export default defineComponent({
   props: {
     clickedRow: String,
@@ -161,6 +165,7 @@ export default defineComponent({
     sites: Array as PropType<Site[]>,
     selectedBranch: String,
     balancers: Array as PropType<Balancer[]>,
+    certificates: Array as PropType<Certificate[]>,
   },
 
   emits: ['edit-shown-changed', 'call-load-certificate'],
@@ -203,7 +208,8 @@ export default defineComponent({
     },
 
     isActiveEditOptionChanged() {
-      const isAttachChanged = (_.differenceBy(this.selectedApps, this.assignedApps, 'id').length > 0) || (_.differenceBy(this.assignedApps, this.selectedApps, 'id').length > 0)
+      const isAttachChanged = (_.differenceBy(this.selectedApps, this.assignedApps, 'id').length > 0) ||
+        (_.differenceBy(this.assignedApps, this.selectedApps, 'id').length > 0)
       const isAttachActiveAndChanged = this.isAttachSelectedOnEdit && isAttachChanged
       const isReplaceActiveAndChanged = this.isReplaceSelectedOnEdit && this.selectedCertId
       return isAttachActiveAndChanged || isReplaceActiveAndChanged
@@ -216,7 +222,7 @@ export default defineComponent({
     },
 
     sitesByCertNameMap() {
-      const returnValue : {[key: string]: string[]} = {}
+      const returnValue: { [key: string]: string[] } = {}
       this.sites?.forEach((site: Site) => {
         const certId = site.ssl_certificate
         if (certId) {
@@ -229,25 +235,33 @@ export default defineComponent({
       return returnValue
     },
 
-    assignedCertsNames() {
-      const certs = new Set(Object.keys(this.sitesByCertNameMap))
+    assignedCerts() {
+      const assignedCerts: Certificate[] = []
       this.balancers.forEach((balancer: Balancer) => {
         balancer.certificates.forEach((link: string) => {
-          certs.add(this.findLocalCertificateNameWithLink(link))
+          const certificateId = this.findLocalCertificateNameWithLink(link)
+          const certificate = _.find(this.certificates, (certificate) => {
+            return certificate.id === certificateId
+          })
+          if (certificate) {
+            assignedCerts.push(certificate)
+          }
         })
       })
-      return [...certs]
+      return assignedCerts
     },
 
-    assignedCertsNamesExceptCurrent() {
-      return this.assignedCertsNames.filter((cert) => cert !== this.localCert.id)
+    assignedCertsExceptCurrent() {
+      return this.assignedCerts.filter((cert: Certificate) => {
+        return cert.name !== this.localCert.name
+      })
     },
 
-    certCanReplaceByLE():any {
+    certCanReplaceByLE(): any {
       return !this.localCert.san || !this.localCert.san.toString().includes('*')
     },
 
-    getConnectedSitesForEditCert():string {
+    getConnectedSitesForEditCert(): string {
       if (this.sitesByCertNameMap[this.localCert.id]) {
         return this.sitesByCertNameMap[this.localCert.id].join(' , ')
       }
@@ -269,18 +283,24 @@ export default defineComponent({
       this.certAction = 'attach_to_application'
     },
 
-    findLocalCertificateNameWithLink(providerLink:string): string {
-      const gcpLink = _.find(this.certificate.links, (link) => {
-        return link.provider === 'gcp'
+    findLocalCertificateNameWithLink(providerLink: string): string {
+      const certificate = _.find(this.certificates, (certificate: Certificate) => {
+        const gcpLink: Link = _.find(certificate.links, (link) => {
+          return link.provider === 'gcp'
+        })
+        if (gcpLink?.link === providerLink) {
+          return true
+        }
+        const awsLink: Link = _.find(certificate.links, (link) => {
+          return link.provider === 'aws'
+        })
+        if (awsLink?.link === providerLink) {
+          return true
+        }
+        return false
       })
-      if (gcpLink?.link === providerLink) {
-        return this.certificate.id
-      }
-      const awsLink = _.find(this.certificate.links, (link) => {
-        return link.provider === 'aws'
-      })
-      if (awsLink?.link === providerLink) {
-        return this.certificate.id
+      if (certificate) {
+        return certificate.id
       }
       const defaultCertName = providerLink.split('/')
       return defaultCertName[defaultCertName.length - 1] + '(*)'

--- a/src/doc-editors/popups/GenerateCertificate.vue
+++ b/src/doc-editors/popups/GenerateCertificate.vue
@@ -7,31 +7,31 @@
             Generate certificate
           </h5>
           <button class="delete"
-            aria-label="close"
-            @click="closeAndResetUploadModal" />
+                  aria-label="close"
+                  @click="closeAndResetUploadModal"/>
         </header>
         <section class="modal-card-body">
           <div class="tile is-3">
             <div class="control modal-location">
               <label for="manual"
-                class="radio is-size-7">
+                     class="radio is-size-7">
                 <input type="radio"
-                  name="isManualInput"
-                  id="manual"
-                  :value="true"
-                  v-model="isManualInput"
-                  @change="inputTypeChagned">
+                       name="isManualInput"
+                       id="manual"
+                       :value="true"
+                       v-model="isManualInput"
+                       @change="inputTypeChagned">
                 Manual input
               </label>
               <br>
               <label for="extract"
-                class="radio is-size-7">
+                     class="radio is-size-7">
                 <input type="radio"
-                  name="isManualInput"
-                  id="extract"
-                  :value="false"
-                  v-model="isManualInput"
-                  @change="inputTypeChagned">
+                       name="isManualInput"
+                       id="extract"
+                       :value="false"
+                       v-model="isManualInput"
+                       @change="inputTypeChagned">
                 Extract pfx file
               </label>
             </div>
@@ -51,13 +51,13 @@
                 <div class="file has-name control is-small">
                   <label class="file-label">
                     <input class="file-input"
-                      type="file"
-                      name="certFile"
-                      @input="loadFile"
-                      accept=".pfx">
+                           type="file"
+                           name="certFile"
+                           @input="loadFile"
+                           accept=".pfx">
                     <span class="file-cta">
                       <span class="file-icon">
-                        <i class="fas fa-upload" />
+                        <i class="fas fa-upload"/>
                       </span>
                       <span class="file-label">
                         Choose a PFX file
@@ -71,22 +71,22 @@
               </form>
             </div>
             <div class="field"
-              v-show="certFile && !privateKey">
+                 v-show="certFile && !privateKey">
               <label class="label is-small">Password</label>
               <div class="control tile is-8">
                 <input class="input is-small"
-                  ref="pfxPass"
-                  type="text"
-                  v-model="pfxPassword">
+                       ref="pfxPass"
+                       type="text"
+                       v-model="pfxPassword">
                 <button @click="extractCertFile"
-                  :disabled="isExtractDisabled || !pfxPassword"
-                  class="button is-small is-info control ml-1"
-                  :class="{ 'is-loading': isExtracting }">
+                        :disabled="isExtractDisabled || !pfxPassword"
+                        class="button is-small is-info control ml-1"
+                        :class="{ 'is-loading': isExtracting }">
                   Extract file
                 </button>
               </div>
               <p :style="{ visibility: isPasswordWarning ? 'visible' : 'hidden' }"
-                class="help is-danger">
+                 class="help is-danger">
                 {{ passwordMessage }}
               </p>
             </div>
@@ -97,18 +97,18 @@
               <label class="label is-small">Private key</label>
               <div class="control">
                 <textarea v-model="privateKey"
-                  class="textarea is-small"
-                  :disabled="!isManualInput"
-                  :placeholder="EMPTY_CERTIFICATE_KEY_FIELD"/>
+                          class="textarea is-small"
+                          :disabled="!isManualInput"
+                          :placeholder="EMPTY_CERTIFICATE_KEY_FIELD"/>
               </div>
             </div>
             <div class="field">
               <label class="label is-small">Certificate</label>
               <div class="control">
                 <textarea v-model="certificate"
-                  class="textarea is-small certificate-data"
-                  :placeholder="EMPTY_CERTIFICATE_FIELD"
-                  rows="8"/>
+                          class="textarea is-small certificate-data"
+                          :placeholder="EMPTY_CERTIFICATE_FIELD"
+                          rows="8"/>
               </div>
             </div>
           </div>
@@ -116,13 +116,13 @@
         <footer class="modal-card-foot">
           <div class="buttons is-right is-fullwidth">
             <button class="button is-small"
-              @click="closeAndResetUploadModal">
+                    @click="closeAndResetUploadModal">
               Cancel
             </button>
             <button class="button is-small is-outlined"
-              :class="{ 'is-loading': isLoading }"
-              :disabled="isSaveNewCertDisabled"
-              @click="uploadManualInputCert">
+                    :class="{ 'is-loading': isLoading }"
+                    :disabled="isSaveNewCertDisabled"
+                    @click="uploadManualInputCert">
               Save
             </button>
           </div>
@@ -165,7 +165,7 @@ export default defineComponent({
       get() {
         return '•'.repeat(this.password.length)
       },
-      set(value:any) {
+      set(value: any) {
         const newVal = value.replaceAll('•', '')
         const password = this.password.substr(0, value.length)
         this.passwordMessage = ''
@@ -209,7 +209,7 @@ export default defineComponent({
       this.removeFile()
     },
 
-    loadFile({target}:any) {
+    loadFile({target}: any) {
       const file: File = target.files[0]
       const extension = file.name.split('.').pop()
       if (extension === 'pfx') {
@@ -260,7 +260,13 @@ export default defineComponent({
         manualCertificateToAdd['private_key'] = this.privateKey
         manualCertificateToAdd['cert_body'] = this.certificate
         const data = manualCertificateToAdd
-        await RequestsUtils.sendReblazeRequest({methodName: 'POST', url, data, successMessage, failureMessage}).then(() => {
+        await RequestsUtils.sendReblazeRequest({
+          methodName: 'POST',
+          url,
+          data,
+          successMessage,
+          failureMessage,
+        }).then(() => {
           this.$emit('generate-shown-changed', false)
           this.$emit('call-load-certificate')
         })
@@ -273,7 +279,8 @@ export default defineComponent({
   },
 })
 </script>
-<style scoped lang="scss">
+<style scoped
+       lang="scss">
 .modal-location {
   margin-bottom: 8px;
   margin-top: -5px;

--- a/src/reblaze-dashboards/DefaultDashboard.vue
+++ b/src/reblaze-dashboards/DefaultDashboard.vue
@@ -104,102 +104,91 @@
       <!--Top tables-->
       <div class="columns is-multiline">
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
+          <rbz-table :columns="topTargetAppsTableColumns"
                      :data="topTargetApps"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP TARGETED SERVICES/APPS">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
-                     :data="topTargetUris"
+          <rbz-table :columns="topTargetURIsTableColumns"
+                     :data="topTargetURIs"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP TARGETED URLs">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
+          <rbz-table :columns="topTargetRTCsTableColumns"
                      :data="topTargetRTCs"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP TARGETED RTCs">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
+          <rbz-table :columns="topCountriesTableColumns"
                      :data="topCountries"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP COUNTRIES">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
+          <rbz-table :columns="topASNumbersTableColumns"
                      :data="topASNumbers"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP AS NUMBERS">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
+          <rbz-table :columns="topIPAddressesTableColumns"
                      :data="topIPAddresses"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP IP ADDRESSES">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
+          <rbz-table :columns="topRateLimitsTableColumns"
                      :data="topRateLimits"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP RATE LIMITS">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
+          <rbz-table :columns="topACLsTableColumns"
                      :data="topACLs"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP ACLs">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
+          <rbz-table :columns="topContentFiltersTableColumns"
                      :data="topContentFilters"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP CONTENT FILTERS">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
+          <rbz-table :columns="topUserAgentsTableColumns"
                      :data="topUserAgents"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP USER AGENT">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
         <div class="column is-6">
-          <rbz-table :columns="topTableColumns"
+          <rbz-table :columns="topTagsTableColumns"
                      :data="topTags"
                      :default-sort-column-index="1"
                      :rows-per-page="10"
-                     default-sort-column-direction="desc"
-                     table-title="TOP TAGS">
+                     default-sort-column-direction="desc">
           </rbz-table>
         </div>
       </div>
@@ -275,8 +264,41 @@ export default defineComponent({
         classes: 'width-80px',
       },
     ]
+    const topTargetAppsTableColumns = _.cloneDeep(topTableColumns)
+    topTargetAppsTableColumns[0].title = 'TOP TARGETED SERVICES/APPS'
+    const topTargetURIsTableColumns = _.cloneDeep(topTableColumns)
+    topTargetURIsTableColumns[0].title = 'TOP TARGETED URLs'
+    const topTargetRTCsTableColumns = _.cloneDeep(topTableColumns)
+    topTargetRTCsTableColumns[0].title = 'TOP TARGETED RTCs'
+    const topCountriesTableColumns = _.cloneDeep(topTableColumns)
+    topCountriesTableColumns[0].title = 'TOP COUNTRIES'
+    const topASNumbersTableColumns = _.cloneDeep(topTableColumns)
+    topASNumbersTableColumns[0].title = 'TOP AS NUMBERS'
+    const topIPAddressesTableColumns = _.cloneDeep(topTableColumns)
+    topIPAddressesTableColumns[0].title = 'TOP IP ADDRESSES'
+    const topRateLimitsTableColumns = _.cloneDeep(topTableColumns)
+    topRateLimitsTableColumns[0].title = 'TOP RATE LIMITS'
+    const topACLsTableColumns = _.cloneDeep(topTableColumns)
+    topACLsTableColumns[0].title = 'TOP ACLs'
+    const topContentFiltersTableColumns = _.cloneDeep(topTableColumns)
+    topContentFiltersTableColumns[0].title = 'TOP CONTENT FILTER RULES'
+    const topUserAgentsTableColumns = _.cloneDeep(topTableColumns)
+    topUserAgentsTableColumns[0].title = 'TOP USER AGENTS'
+    const topTagsTableColumns = _.cloneDeep(topTableColumns)
+    topTagsTableColumns[0].title = 'TOP TAGS'
     return {
       topTableColumns: topTableColumns,
+      topTargetAppsTableColumns: topTargetAppsTableColumns,
+      topTargetURIsTableColumns: topTargetURIsTableColumns,
+      topTargetRTCsTableColumns: topTargetRTCsTableColumns,
+      topCountriesTableColumns: topCountriesTableColumns,
+      topASNumbersTableColumns: topASNumbersTableColumns,
+      topIPAddressesTableColumns: topIPAddressesTableColumns,
+      topRateLimitsTableColumns: topRateLimitsTableColumns,
+      topACLsTableColumns: topACLsTableColumns,
+      topContentFiltersTableColumns: topContentFiltersTableColumns,
+      topUserAgentsTableColumns: topUserAgentsTableColumns,
+      topTagsTableColumns: topTagsTableColumns,
       trafficChartSeriesOptions: [
         {
           title: 'Hits',
@@ -560,7 +582,7 @@ export default defineComponent({
       return returnArray
     },
 
-    topTargetUris(): topTableData[] {
+    topTargetURIs(): topTableData[] {
       return this.buildTopDataFromCounters('top_uri_active', 'top_uri_passed', 'top_uri_reported')
     },
 

--- a/src/views/BackendServicesList.vue
+++ b/src/views/BackendServicesList.vue
@@ -96,7 +96,7 @@ export default defineComponent({
           },
           isSortable: true,
           isSearchable: true,
-          cellContentClasses: 'multi-line white-space-pre ellipsis',
+          cellContentClasses: 'vertical-scroll multi-line white-space-pre ellipsis',
         },
         {
           title: 'Transport Protocol',
@@ -219,10 +219,9 @@ export default defineComponent({
 })
 </script>
 <style scoped lang="scss">
-:deep(.multi-line) {
+:deep(.rbz-table .multi-line) {
   height: fit-content;
-  max-height: fit-content;
-  min-height: 50px;
+  max-height: 5rem;
 }
 </style>
 

--- a/src/views/DocumentList.vue
+++ b/src/views/DocumentList.vue
@@ -362,7 +362,7 @@ export default defineComponent({
               ].join('\n')
             },
             classes: 'width-200px',
-            cellContentClasses: 'white-space-pre ellipsis multi-line',
+            cellContentClasses: 'white-space-pre ellipsis vertical-scroll multi-line',
           },
         ],
         'ratelimits': [
@@ -427,7 +427,7 @@ export default defineComponent({
             isSortable: true,
             isSearchable: true,
             classes: 'width-250px',
-            cellContentClasses: 'multi-line white-space-pre ellipsis',
+            cellContentClasses: 'vertical-scroll multi-line white-space-pre ellipsis',
           },
           {
             title: 'Event',
@@ -574,7 +574,7 @@ export default defineComponent({
             isSortable: true,
             isSearchable: true,
             classes: 'width-170px',
-            cellContentClasses: 'multi-line white-space-pre ellipsis',
+            cellContentClasses: 'vertical-scroll multi-line white-space-pre ellipsis',
           },
           {
             title: 'Decoding',
@@ -594,7 +594,7 @@ export default defineComponent({
             isSortable: true,
             isSearchable: true,
             classes: 'width-100px',
-            cellContentClasses: 'multi-line white-space-pre ellipsis',
+            cellContentClasses: 'vertical-scroll multi-line white-space-pre ellipsis',
           },
           {
             title: 'Custom Response',
@@ -829,10 +829,9 @@ export default defineComponent({
   min-height: 50vh;
 }
 
-:deep(.multi-line) {
+:deep(.rbz-table .multi-line) {
   height: fit-content;
-  max-height: fit-content;
-  min-height: 50px;
+  max-height: 5rem;
 }
 
 @keyframes delayedDisplay {

--- a/src/views/DynamicRulesList.vue
+++ b/src/views/DynamicRulesList.vue
@@ -142,15 +142,16 @@ export default defineComponent({
               const matchingGlobalFilter = _.find(this.globalFiltersData, (globalFilter: GlobalFilter) => {
                 return globalFilter.id === `dr_${item.id}`
               })
-              return matchingGlobalFilter ? matchingGlobalFilter.tags?.join('\n') : ''
+              return matchingGlobalFilter?.tags?.length || 0
             } else {
-              return ''
+              return 0
             }
           },
-          isSortable: false,
+          isSortable: true,
           isSearchable: true,
+          isNumber: true,
           classes: 'width-100px',
-          cellContentClasses: 'multi-line white-space-pre ellipsis',
+          cellContentClasses: 'white-space-pre ellipsis',
         },
       ] as ColumnOptions[],
       isNewLoading: false,
@@ -283,10 +284,3 @@ export default defineComponent({
   },
 })
 </script>
-<style scoped lang="scss">
-:deep(.multi-line) {
-  height: fit-content;
-  max-height: fit-content;
-  min-height: 50px;
-}
-</style>

--- a/src/views/ProxyTemplatesList.vue
+++ b/src/views/ProxyTemplatesList.vue
@@ -95,7 +95,7 @@ export default defineComponent({
             ].join('\n')
           },
           classes: 'width-200px',
-          cellContentClasses: 'multi-line white-space-pre ellipsis',
+          cellContentClasses: 'vertical-scroll multi-line white-space-pre ellipsis',
         },
         {
           title: 'Proxy Timeout',
@@ -108,7 +108,7 @@ export default defineComponent({
             ].join('\n')
           },
           classes: 'width-150px',
-          cellContentClasses: 'multi-line white-space-pre ellipsis',
+          cellContentClasses: 'vertical-scroll multi-line white-space-pre ellipsis',
         },
       ] as ColumnOptions[],
       isNewLoading: false,
@@ -205,10 +205,9 @@ export default defineComponent({
 })
 </script>
 <style scoped lang="scss">
-:deep(.multi-line) {
+:deep(.rbz-table .multi-line) {
   height: fit-content;
-  max-height: fit-content;
-  min-height: 50px;
+  max-height: 5rem;
 }
 </style>
 

--- a/src/views/SslList.vue
+++ b/src/views/SslList.vue
@@ -31,7 +31,7 @@
                    @row-clicked="onSelectedLoadBalancerRow">
           <template #tableMenu="rowProps">
             <tr class="is-size-7 selected"
-                v-if="rowProps.row.id === selectedBalancer?.id">
+                v-if="selectedBalancer?.id && selectedBalancer.id === rowProps.row.id">
               <td colspan="7">
                 <div class="mb-3">
                   <p>
@@ -278,7 +278,7 @@ export default defineComponent({
           },
           isSearchable: true,
           classes: 'width-100px',
-          cellContentClasses: 'ellipsis white-space-pre multi-line',
+          cellContentClasses: 'ellipsis white-space-pre vertical-scroll multi-line',
         },
         {
           title: 'AWS',
@@ -332,7 +332,7 @@ export default defineComponent({
           },
           isSearchable: true,
           classes: 'width-120px',
-          cellContentClasses: 'white-space-pre ellipsis multi-line',
+          cellContentClasses: 'white-space-pre ellipsis vertical-scroll multi-line',
         },
         {
           title: 'SAN',
@@ -657,9 +657,8 @@ export default defineComponent({
   align-items: center;
 }
 
-:deep(.multi-line) {
+:deep(.rbz-table .multi-line) {
   height: fit-content;
-  max-height: fit-content;
-  min-height: 75px;
+  max-height: 10rem;
 }
 </style>

--- a/src/views/SslList.vue
+++ b/src/views/SslList.vue
@@ -164,7 +164,13 @@
                         :selected-balancer="selectedBalancer"
                         :certificates="certificates"
                         @attach-shown-changed="attachCertPopupShown = false"
-                        :attach-certificate-to-load-balancer="attachCertificateToLoadBalancer"
+                        @attach-certificate-to-load-balancer="attachCertificateToLoadBalancer(
+                          $event.selectedBalancer,
+                          $event.certificate.id,
+                          false,
+                          '',
+                          $event.certificate
+                        )"
                         :isAttachLoading="isAttachLoading"/>
   </div>
 </template>
@@ -265,9 +271,7 @@ export default defineComponent({
               const matchingSites: Site[] = _.filter(this.sites, (site: Site) => {
                 return site.ssl_certificate === item.id
               })
-              return matchingSites.length ? _.flatMap(matchingSites, (matchingSite:Site) => {
-                return matchingSite.server_names
-              }).join('\n') : ''
+              return matchingSites.length ? _.map(matchingSites, 'name').join('\n') : ''
             } else {
               return ''
             }
@@ -513,7 +517,11 @@ export default defineComponent({
       this.attachCertificateToLoadBalancer(balancer, cert, true, certificateLink)
     },
 
-    async attachCertificateToLoadBalancer(balancer:Balancer, cert:string, isDefault:boolean = false, certificateLink?: string, certificate?: Certificate) {
+    async attachCertificateToLoadBalancer(balancer: Balancer,
+                                          cert: string,
+                                          isDefault: boolean = false,
+                                          certificateLink?: string,
+                                          certificate?: Certificate) {
       balancer.attach_loading = certificateLink
       if (certificate) {
         certificate.loading = true
@@ -597,14 +605,14 @@ export default defineComponent({
     },
 
     findLocalCertificateNameWithLink(providerLink: string) {
-      const certificate = _.find(this.certificates, (certificate:Certificate) => {
-        const gcpLink:Link = _.find(certificate.links, (link) => {
+      const certificate = _.find(this.certificates, (certificate: Certificate) => {
+        const gcpLink: Link = _.find(certificate.links, (link) => {
           return link.provider === 'gcp'
         })
         if (gcpLink?.link === providerLink) {
           return true
         }
-        const awsLink:Link = _.find(certificate.links, (link) => {
+        const awsLink: Link = _.find(certificate.links, (link) => {
           return link.provider === 'aws'
         })
         if (awsLink?.link === providerLink) {


### PR DESCRIPTION
Update version to v5.0.5

Fix bug in Server Groups editor where empty lines in server names field (hosts) were not being filtered out
Change design of default dashboard's top tables, the title is no longer in a separate header line
Change design of arrows in RbzTables, now only the active arrow is displayed instead of all arrows
Add feature to listen to location changes in response headers received from the server and redirect the client accordingly
Fix issue in SSL displaying IDs and not names on replace tab
Fix issue in SSL table displaying server names of connected Server Groups instead of Server Group names
Fix lint issues
Fix issues in table multi line height
Change color of table headers
Fix errors being thrown in console during load balancers load